### PR TITLE
Move facet-tokio-postgres into dibs repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,38 @@ jobs:
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
+
+  test-tokio-postgres:
+    name: Test tokio-postgres
+    runs-on: depot-ubuntu-24.04-4
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run facet-tokio-postgres tests
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+        run: cargo nextest run -p facet-tokio-postgres --features test-postgres

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ dockside = { path = "crates/dockside" }
 # facet ecosystem
 facet = { git = "https://github.com/facet-rs/facet", branch = "main" }
 facet-args = { git = "https://github.com/facet-rs/facet", branch = "main" }
-facet-tokio-postgres = { git = "https://github.com/facet-rs/facet", branch = "main" }
+facet-core = { git = "https://github.com/facet-rs/facet", branch = "main" }
+facet-reflect = { git = "https://github.com/facet-rs/facet", branch = "main" }
 facet-testhelpers = { git = "https://github.com/facet-rs/facet", branch = "main" }
+facet-tokio-postgres = { path = "crates/facet-tokio-postgres" }
 
 # styx ecosystem
 facet-styx = { git = "https://github.com/bearcove/styx", branch = "main" }
@@ -52,7 +54,9 @@ tokio-tungstenite = "0.26"
 bytes = "1"
 chrono = "0.4"
 jiff = "0.2"
+postgres-types = "0.2"
 rust_decimal = { version = "1", default-features = false, features = ["std"] }
+time = "0.3"
 uuid = "1"
 
 # error handling
@@ -84,6 +88,8 @@ inventory = "0.3"
 # dev/test dependencies
 insta = "1"
 proptest = "1"
+testcontainers = "0.26"
+testcontainers-modules = { version = "0.14", features = ["postgres"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
@@ -101,20 +107,19 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # facet-reflect = { path = "/Users/amos/bearcove/facet/facet-reflect" }
 # facet-solver = { path = "/Users/amos/bearcove/facet/facet-solver" }
 # facet-testhelpers = { path = "/Users/amos/bearcove/facet/facet-testhelpers" }
-# facet-tokio-postgres = { path = "/Users/amos/bearcove/facet/facet-tokio-postgres" }
 # facet-toml = { path = "/Users/amos/bearcove/facet/facet-toml" }
 # facet-value = { path = "/Users/amos/bearcove/facet/facet-value" }
 
-[patch."https://github.com/bearcove/styx"]
-facet-styx = { path = "/Users/amos/bearcove/styx/crates/facet-styx" }
-styx-embed = { path = "/Users/amos/bearcove/styx/crates/styx-embed" }
-styx-tree = { path = "/Users/amos/bearcove/styx/crates/styx-tree" }
-styx-parse = { path = "/Users/amos/bearcove/styx/crates/styx-parse" }
-styx-cst = { path = "/Users/amos/bearcove/styx/crates/styx-cst" }
-styx-format = { path = "/Users/amos/bearcove/styx/crates/styx-format" }
-styx-lsp-ext = { path = "/Users/amos/bearcove/styx/crates/styx-lsp-ext" }
-styx-lsp = { path = "/Users/amos/bearcove/styx/crates/styx-lsp" }
-styx-lsp-test-schema = { path = "/Users/amos/bearcove/styx/crates/styx-lsp-test-schema" }
+# [patch."https://github.com/bearcove/styx"]
+# facet-styx = { path = "/Users/amos/bearcove/styx/crates/facet-styx" }
+# styx-embed = { path = "/Users/amos/bearcove/styx/crates/styx-embed" }
+# styx-tree = { path = "/Users/amos/bearcove/styx/crates/styx-tree" }
+# styx-parse = { path = "/Users/amos/bearcove/styx/crates/styx-parse" }
+# styx-cst = { path = "/Users/amos/bearcove/styx/crates/styx-cst" }
+# styx-format = { path = "/Users/amos/bearcove/styx/crates/styx-format" }
+# styx-lsp-ext = { path = "/Users/amos/bearcove/styx/crates/styx-lsp-ext" }
+# styx-lsp = { path = "/Users/amos/bearcove/styx/crates/styx-lsp" }
+# styx-lsp-test-schema = { path = "/Users/amos/bearcove/styx/crates/styx-lsp-test-schema" }
 
 # [patch."https://github.com/bearcove/roam"]
 # roam = { path = "/Users/amos/bearcove/roam/rust/roam" }

--- a/crates/facet-tokio-postgres/Cargo.toml
+++ b/crates/facet-tokio-postgres/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "facet-tokio-postgres"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Deserialize tokio-postgres Rows into any type implementing Facet"
+keywords = ["postgres", "tokio-postgres", "facet", "deserialization", "database"]
+categories = ["database", "asynchronous"]
+homepage = "https://facet.rs"
+
+[package.metadata]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]
+facet-core = { workspace = true }
+facet-reflect = { workspace = true }
+tokio-postgres = { workspace = true }
+postgres-types = { workspace = true }
+rust_decimal = { workspace = true, optional = true, features = ["db-tokio-postgres"] }
+jiff = { workspace = true, optional = true }
+
+[dev-dependencies]
+facet = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }
+uuid = { workspace = true }
+jiff = { workspace = true }
+chrono = { workspace = true }
+time = { workspace = true }
+
+[features]
+default = ["std"]
+std = []
+# Enable integration tests (requires postgres via POSTGRES_HOST/PORT env vars, or docker for testcontainers)
+test-postgres = []
+# Enable UUID support
+uuid = ["facet-core/uuid"]
+# Enable jiff timestamp support
+jiff02 = ["dep:jiff", "facet-core/jiff02", "tokio-postgres/with-jiff-0_2", "postgres-types/with-jiff-0_2"]
+# Enable chrono timestamp support
+chrono = ["facet-core/chrono"]
+# Enable time crate support
+time = ["facet-core/time"]
+# Enable rust_decimal::Decimal support for NUMERIC columns
+rust_decimal = ["dep:rust_decimal", "facet-core/rust_decimal"]

--- a/crates/facet-tokio-postgres/README.md
+++ b/crates/facet-tokio-postgres/README.md
@@ -1,0 +1,8 @@
+# facet-tokio-postgres
+
+Deserialize tokio-postgres Rows into any type implementing Facet.
+
+This crate provides a bridge between tokio-postgres and facet, allowing you to
+deserialize database rows directly into Rust structs that implement `Facet`.
+
+Part of the [dibs](https://github.com/bearcove/dibs) project.

--- a/crates/facet-tokio-postgres/README.md.in
+++ b/crates/facet-tokio-postgres/README.md.in
@@ -1,0 +1,8 @@
+# facet-tokio-postgres
+
+Deserialize tokio-postgres Rows into any type implementing Facet.
+
+This crate provides a bridge between tokio-postgres and facet, allowing you to
+deserialize database rows directly into Rust structs that implement `Facet`.
+
+Part of the [dibs](https://github.com/bearcove/dibs) project.

--- a/crates/facet-tokio-postgres/arborium-header.html
+++ b/crates/facet-tokio-postgres/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@2/dist/arborium.iife.js"></script>

--- a/crates/facet-tokio-postgres/src/lib.rs
+++ b/crates/facet-tokio-postgres/src/lib.rs
@@ -1,0 +1,504 @@
+//! Deserialize tokio-postgres Rows into any type implementing Facet.
+//!
+//! This crate provides a bridge between tokio-postgres and facet, allowing you to
+//! deserialize database rows directly into Rust structs that implement `Facet`.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use facet::Facet;
+//! use facet_tokio_postgres::from_row;
+//!
+//! #[derive(Debug, Facet)]
+//! struct User {
+//!     id: i32,
+//!     name: String,
+//!     email: Option<String>,
+//! }
+//!
+//! // After executing a query...
+//! let row = client.query_one("SELECT id, name, email FROM users WHERE id = $1", &[&1]).await?;
+//! let user: User = from_row(&row)?;
+//! ```
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use facet_core::{Facet, Shape, StructKind, Type, UserType};
+use facet_reflect::{Partial, ReflectError};
+use tokio_postgres::Row;
+
+/// Error type for Row deserialization.
+#[derive(Debug)]
+pub enum Error {
+    /// A required column was not found in the row
+    MissingColumn {
+        /// Name of the missing column
+        column: String,
+    },
+    /// The column type doesn't match the expected Rust type
+    TypeMismatch {
+        /// Name of the column
+        column: String,
+        /// Expected type
+        expected: &'static Shape,
+        /// Actual error from postgres
+        source: tokio_postgres::Error,
+    },
+    /// Error from facet reflection
+    Reflect(ReflectError),
+    /// The target type is not a struct
+    NotAStruct {
+        /// The shape we tried to deserialize into
+        shape: &'static Shape,
+    },
+    /// Unsupported field type
+    UnsupportedType {
+        /// Name of the field
+        field: String,
+        /// The shape of the field
+        shape: &'static Shape,
+    },
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::MissingColumn { column } => write!(f, "missing column: {column}"),
+            Error::TypeMismatch {
+                column, expected, ..
+            } => {
+                write!(
+                    f,
+                    "type mismatch for column '{column}': expected {expected}"
+                )
+            }
+            Error::Reflect(e) => write!(f, "reflection error: {e}"),
+            Error::NotAStruct { shape } => {
+                write!(f, "cannot deserialize row into non-struct type: {shape}")
+            }
+            Error::UnsupportedType { field, shape } => {
+                write!(f, "unsupported type for field '{field}': {shape}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::TypeMismatch { source, .. } => Some(source),
+            Error::Reflect(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<ReflectError> for Error {
+    fn from(e: ReflectError) -> Self {
+        Error::Reflect(e)
+    }
+}
+
+/// Result type for Row deserialization.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Deserialize a tokio-postgres Row into any type implementing Facet.
+///
+/// The type must be a struct with named fields. Each field name is used to look up
+/// the corresponding column in the row.
+///
+/// # Example
+///
+/// ```ignore
+/// use facet::Facet;
+/// use facet_tokio_postgres::from_row;
+///
+/// #[derive(Debug, Facet)]
+/// struct User {
+///     id: i32,
+///     name: String,
+///     active: bool,
+/// }
+///
+/// let row = client.query_one("SELECT id, name, active FROM users LIMIT 1", &[]).await?;
+/// let user: User = from_row(&row)?;
+/// ```
+pub fn from_row<'facet, T: Facet<'facet>>(row: &Row) -> Result<T> {
+    let partial = Partial::alloc::<T>()?;
+    let partial = deserialize_row_into(row, partial, T::SHAPE)?;
+    let heap_value = partial.build()?;
+    Ok(heap_value.materialize()?)
+}
+
+/// Internal function to deserialize a row into a Partial.
+fn deserialize_row_into<'p>(
+    row: &Row,
+    partial: Partial<'p>,
+    shape: &'static Shape,
+) -> Result<Partial<'p>> {
+    let struct_def = match &shape.ty {
+        Type::User(UserType::Struct(s)) if s.kind == StructKind::Struct => s,
+        _ => {
+            return Err(Error::NotAStruct { shape });
+        }
+    };
+
+    let mut partial = partial;
+    let num_fields = struct_def.fields.len();
+    let mut fields_set = alloc::vec![false; num_fields];
+
+    for (idx, field) in struct_def.fields.iter().enumerate() {
+        let column_name = field.rename.unwrap_or(field.name);
+
+        // Check if column exists
+        let column_idx = match row.columns().iter().position(|c| c.name() == column_name) {
+            Some(idx) => idx,
+            None => {
+                // Try to set default for missing column
+                partial =
+                    partial
+                        .set_nth_field_to_default(idx)
+                        .map_err(|_| Error::MissingColumn {
+                            column: column_name.to_string(),
+                        })?;
+                fields_set[idx] = true;
+                continue;
+            }
+        };
+
+        partial = partial.begin_field(field.name)?;
+        partial = deserialize_column(row, column_idx, column_name, partial, field.shape())?;
+        partial = partial.end()?;
+        fields_set[idx] = true;
+    }
+
+    Ok(partial)
+}
+
+/// Deserialize a single column value into a Partial.
+fn deserialize_column<'p>(
+    row: &Row,
+    column_idx: usize,
+    column_name: &str,
+    partial: Partial<'p>,
+    shape: &'static Shape,
+) -> Result<Partial<'p>> {
+    use facet_core::{Def, NumericType, PrimitiveType};
+
+    let mut partial = partial;
+
+    // Handle Option types first
+    if let Def::Option(_) = &shape.def {
+        return deserialize_option_column(row, column_idx, column_name, partial, shape);
+    }
+
+    // Handle based on type
+    match &shape.ty {
+        // Signed integers
+        Type::Primitive(PrimitiveType::Numeric(NumericType::Integer { signed: true })) => {
+            match shape.type_identifier {
+                "i8" => {
+                    let val: i8 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val)?;
+                }
+                "i16" => {
+                    let val: i16 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val)?;
+                }
+                "i32" => {
+                    let val: i32 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val)?;
+                }
+                "i64" => {
+                    let val: i64 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val)?;
+                }
+                _ => {
+                    return Err(Error::UnsupportedType {
+                        field: column_name.to_string(),
+                        shape,
+                    });
+                }
+            }
+        }
+
+        // Unsigned integers (postgres doesn't have native unsigned, but we can try)
+        Type::Primitive(PrimitiveType::Numeric(NumericType::Integer { signed: false })) => {
+            // Postgres doesn't have unsigned types natively, so we read as signed and convert
+            match shape.type_identifier {
+                "u8" => {
+                    let val: i16 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val as u8)?;
+                }
+                "u16" => {
+                    let val: i32 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val as u16)?;
+                }
+                "u32" => {
+                    let val: i64 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val as u32)?;
+                }
+                "u64" => {
+                    // For u64, we might need to use BIGINT and hope it fits
+                    let val: i64 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val as u64)?;
+                }
+                _ => {
+                    return Err(Error::UnsupportedType {
+                        field: column_name.to_string(),
+                        shape,
+                    });
+                }
+            }
+        }
+
+        // Floats
+        Type::Primitive(PrimitiveType::Numeric(NumericType::Float)) => {
+            match shape.type_identifier {
+                "f32" => {
+                    let val: f32 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val)?;
+                }
+                "f64" => {
+                    let val: f64 = get_column(row, column_idx, column_name, shape)?;
+                    partial = partial.set(val)?;
+                }
+                _ => {
+                    return Err(Error::UnsupportedType {
+                        field: column_name.to_string(),
+                        shape,
+                    });
+                }
+            }
+        }
+
+        // Booleans
+        Type::Primitive(PrimitiveType::Boolean) => {
+            let val: bool = get_column(row, column_idx, column_name, shape)?;
+            partial = partial.set(val)?;
+        }
+
+        // Strings
+        Type::Primitive(PrimitiveType::Textual(_)) | Type::User(_)
+            if shape.type_identifier == "String" =>
+        {
+            let val: String = get_column(row, column_idx, column_name, shape)?;
+            partial = partial.set(val)?;
+        }
+
+        // Vec<u8> for bytea - check if it's a List of u8
+        _ if matches!(&shape.def, Def::List(_))
+            && shape
+                .inner
+                .is_some_and(|inner| inner.type_identifier == "u8") =>
+        {
+            let val: Vec<u8> = get_column(row, column_idx, column_name, shape)?;
+            partial = partial.set(val)?;
+        }
+
+        // rust_decimal::Decimal for NUMERIC columns
+        #[cfg(feature = "rust_decimal")]
+        _ if shape.type_identifier == "Decimal" => {
+            let val: rust_decimal::Decimal = get_column(row, column_idx, column_name, shape)?;
+            partial = partial.set(val)?;
+        }
+
+        // jiff::Timestamp for TIMESTAMPTZ columns
+        #[cfg(feature = "jiff02")]
+        _ if shape.type_identifier == "Timestamp" && shape.module_path == Some("jiff") => {
+            let val: jiff::Timestamp = get_column(row, column_idx, column_name, shape)?;
+            partial = partial.set(val)?;
+        }
+
+        // jiff::civil::DateTime for TIMESTAMP (without timezone) columns
+        #[cfg(feature = "jiff02")]
+        _ if shape.type_identifier == "DateTime" && shape.module_path == Some("jiff") => {
+            let val: jiff::civil::DateTime = get_column(row, column_idx, column_name, shape)?;
+            partial = partial.set(val)?;
+        }
+
+        // Fallback: try to use parse if the type supports it
+        _ => {
+            if shape.vtable.has_parse() {
+                // Try getting as string and parsing
+                let val: String = get_column(row, column_idx, column_name, shape)?;
+                partial = partial.parse_from_str(&val)?;
+            } else {
+                return Err(Error::UnsupportedType {
+                    field: column_name.to_string(),
+                    shape,
+                });
+            }
+        }
+    }
+
+    Ok(partial)
+}
+
+/// Deserialize an Option column.
+fn deserialize_option_column<'p>(
+    row: &Row,
+    column_idx: usize,
+    column_name: &str,
+    partial: Partial<'p>,
+    shape: &'static Shape,
+) -> Result<Partial<'p>> {
+    use facet_core::{NumericType, PrimitiveType};
+
+    let inner_shape = shape.inner.expect("Option must have inner shape");
+    let mut partial = partial;
+
+    // Try to get the value directly as Option<T> for the appropriate type
+    // This handles NULL detection properly for each type
+    macro_rules! try_option {
+        ($t:ty) => {{
+            let val: Option<$t> = get_column(row, column_idx, column_name, shape)?;
+            match val {
+                Some(v) => {
+                    partial = partial.begin_some()?;
+                    partial = partial.set(v)?;
+                    partial = partial.end()?;
+                }
+                None => {
+                    partial = partial.set_default()?;
+                }
+            }
+            return Ok(partial);
+        }};
+    }
+
+    // Match on inner type to get the right Option<T>
+    match &inner_shape.ty {
+        Type::Primitive(PrimitiveType::Numeric(NumericType::Integer { signed: true })) => {
+            match inner_shape.type_identifier {
+                "i8" => try_option!(i8),
+                "i16" => try_option!(i16),
+                "i32" => try_option!(i32),
+                "i64" => try_option!(i64),
+                _ => {}
+            }
+        }
+        Type::Primitive(PrimitiveType::Numeric(NumericType::Integer { signed: false })) => {
+            // Postgres doesn't have unsigned, read as next larger signed type
+            match inner_shape.type_identifier {
+                "u8" => {
+                    let val: Option<i16> = get_column(row, column_idx, column_name, shape)?;
+                    match val {
+                        Some(v) => {
+                            partial = partial.begin_some()?;
+                            partial = partial.set(v as u8)?;
+                            partial = partial.end()?;
+                        }
+                        None => {
+                            partial = partial.set_default()?;
+                        }
+                    }
+                    return Ok(partial);
+                }
+                "u16" => {
+                    let val: Option<i32> = get_column(row, column_idx, column_name, shape)?;
+                    match val {
+                        Some(v) => {
+                            partial = partial.begin_some()?;
+                            partial = partial.set(v as u16)?;
+                            partial = partial.end()?;
+                        }
+                        None => {
+                            partial = partial.set_default()?;
+                        }
+                    }
+                    return Ok(partial);
+                }
+                "u32" => {
+                    let val: Option<i64> = get_column(row, column_idx, column_name, shape)?;
+                    match val {
+                        Some(v) => {
+                            partial = partial.begin_some()?;
+                            partial = partial.set(v as u32)?;
+                            partial = partial.end()?;
+                        }
+                        None => {
+                            partial = partial.set_default()?;
+                        }
+                    }
+                    return Ok(partial);
+                }
+                "u64" => {
+                    let val: Option<i64> = get_column(row, column_idx, column_name, shape)?;
+                    match val {
+                        Some(v) => {
+                            partial = partial.begin_some()?;
+                            partial = partial.set(v as u64)?;
+                            partial = partial.end()?;
+                        }
+                        None => {
+                            partial = partial.set_default()?;
+                        }
+                    }
+                    return Ok(partial);
+                }
+                _ => {}
+            }
+        }
+        Type::Primitive(PrimitiveType::Numeric(NumericType::Float)) => {
+            match inner_shape.type_identifier {
+                "f32" => try_option!(f32),
+                "f64" => try_option!(f64),
+                _ => {}
+            }
+        }
+        Type::Primitive(PrimitiveType::Boolean) => try_option!(bool),
+        _ if inner_shape.type_identifier == "String" => try_option!(String),
+        #[cfg(feature = "rust_decimal")]
+        _ if inner_shape.type_identifier == "Decimal" => try_option!(rust_decimal::Decimal),
+        #[cfg(feature = "jiff02")]
+        _ if inner_shape.type_identifier == "Timestamp"
+            && inner_shape.module_path == Some("jiff") =>
+        {
+            try_option!(jiff::Timestamp)
+        }
+        #[cfg(feature = "jiff02")]
+        _ if inner_shape.type_identifier == "DateTime"
+            && inner_shape.module_path == Some("jiff") =>
+        {
+            try_option!(jiff::civil::DateTime)
+        }
+        _ => {}
+    }
+
+    // Fallback: try String and parse
+    if inner_shape.vtable.has_parse() {
+        let val: Option<String> = get_column(row, column_idx, column_name, shape)?;
+        match val {
+            Some(s) => {
+                partial = partial.begin_some()?;
+                partial = partial.parse_from_str(&s)?;
+                partial = partial.end()?;
+            }
+            None => {
+                partial = partial.set_default()?;
+            }
+        }
+        return Ok(partial);
+    }
+
+    Err(Error::UnsupportedType {
+        field: column_name.to_string(),
+        shape: inner_shape,
+    })
+}
+
+/// Get a column value with proper error handling.
+fn get_column<'a, T>(row: &'a Row, idx: usize, name: &str, shape: &'static Shape) -> Result<T>
+where
+    T: postgres_types::FromSql<'a>,
+{
+    row.try_get::<_, T>(idx).map_err(|e| Error::TypeMismatch {
+        column: name.to_string(),
+        expected: shape,
+        source: e,
+    })
+}

--- a/crates/facet-tokio-postgres/tests/integration.rs
+++ b/crates/facet-tokio-postgres/tests/integration.rs
@@ -1,0 +1,872 @@
+//! Integration tests for facet-tokio-postgres.
+//!
+//! These tests require the `test-postgres` feature to be enabled.
+//! They support two modes:
+//! - CI mode: Uses GitHub service container (set POSTGRES_HOST and POSTGRES_PORT env vars)
+//! - Local mode: Uses testcontainers to spin up a postgres container (requires docker)
+
+#![cfg(feature = "test-postgres")]
+
+use facet::Facet;
+use facet_tokio_postgres::from_row;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use tokio_postgres::NoTls;
+
+/// Holds the postgres connection and optionally the container (for local mode).
+/// The container must be kept alive for the duration of the test.
+struct PostgresHandle {
+    client: tokio_postgres::Client,
+    _container: Option<testcontainers::ContainerAsync<Postgres>>,
+}
+
+async fn setup_postgres() -> PostgresHandle {
+    // Check for CI mode (service container)
+    if let (Ok(host), Ok(port)) = (
+        std::env::var("POSTGRES_HOST"),
+        std::env::var("POSTGRES_PORT"),
+    ) {
+        let conn_string = format!("host={host} port={port} user=postgres password=postgres");
+        let (client, connection) = tokio_postgres::connect(&conn_string, NoTls).await.unwrap();
+
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        return PostgresHandle {
+            client,
+            _container: None,
+        };
+    }
+
+    // Local mode: use testcontainers
+    let container = Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+
+    let conn_string = format!("host={host} port={port} user=postgres password=postgres");
+    let (client, connection) = tokio_postgres::connect(&conn_string, NoTls).await.unwrap();
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    PostgresHandle {
+        client,
+        _container: Some(container),
+    }
+}
+
+#[tokio::test]
+async fn test_basic_struct() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct User {
+        id: i32,
+        name: String,
+        active: bool,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    // Create table
+    client
+        .execute(
+            "CREATE TABLE users (id INTEGER, name TEXT, active BOOLEAN)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert data
+    client
+        .execute(
+            "INSERT INTO users (id, name, active) VALUES (1, 'Alice', true)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Query and deserialize
+    let row = client
+        .query_one("SELECT id, name, active FROM users", &[])
+        .await
+        .unwrap();
+
+    let user: User = from_row(&row).unwrap();
+
+    assert_eq!(user.id, 1);
+    assert_eq!(user.name, "Alice");
+    assert!(user.active);
+}
+
+#[tokio::test]
+async fn test_optional_fields() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct Person {
+        id: i32,
+        name: String,
+        email: Option<String>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE people (id INTEGER, name TEXT, email TEXT)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with NULL email
+    client
+        .execute(
+            "INSERT INTO people (id, name, email) VALUES (1, 'Bob', NULL)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with email
+    client
+        .execute(
+            "INSERT INTO people (id, name, email) VALUES (2, 'Carol', 'carol@example.com')",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let rows = client
+        .query("SELECT id, name, email FROM people ORDER BY id", &[])
+        .await
+        .unwrap();
+
+    let bob: Person = from_row(&rows[0]).unwrap();
+    assert_eq!(bob.id, 1);
+    assert_eq!(bob.name, "Bob");
+    assert_eq!(bob.email, None);
+
+    let carol: Person = from_row(&rows[1]).unwrap();
+    assert_eq!(carol.id, 2);
+    assert_eq!(carol.name, "Carol");
+    assert_eq!(carol.email, Some("carol@example.com".to_string()));
+}
+
+#[tokio::test]
+async fn test_numeric_types() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct Numbers {
+        small: i16,
+        medium: i32,
+        large: i64,
+        float32: f32,
+        float64: f64,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE numbers (small SMALLINT, medium INTEGER, large BIGINT, float32 REAL, float64 DOUBLE PRECISION)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO numbers VALUES (42, 1000000, 9223372036854775807, 1.5, 2.5)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT * FROM numbers", &[])
+        .await
+        .unwrap();
+
+    let nums: Numbers = from_row(&row).unwrap();
+
+    assert_eq!(nums.small, 42);
+    assert_eq!(nums.medium, 1_000_000);
+    assert_eq!(nums.large, 9_223_372_036_854_775_807);
+    assert!((nums.float32 - 1.5).abs() < 0.001);
+    assert!((nums.float64 - 2.5).abs() < 0.0000001);
+}
+
+#[tokio::test]
+async fn test_bytea() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct BinaryData {
+        id: i32,
+        data: Vec<u8>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute("CREATE TABLE binary_data (id INTEGER, data BYTEA)", &[])
+        .await
+        .unwrap();
+
+    let bytes: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF];
+    client
+        .execute("INSERT INTO binary_data VALUES (1, $1)", &[&bytes])
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT * FROM binary_data", &[])
+        .await
+        .unwrap();
+
+    let result: BinaryData = from_row(&row).unwrap();
+
+    assert_eq!(result.id, 1);
+    assert_eq!(result.data, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+}
+
+#[tokio::test]
+async fn test_field_alias() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct AliasedUser {
+        #[facet(rename = "user_id")]
+        id: i32,
+        #[facet(rename = "user_name")]
+        name: String,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE aliased_users (user_id INTEGER, user_name TEXT)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute("INSERT INTO aliased_users VALUES (42, 'Dave')", &[])
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT * FROM aliased_users", &[])
+        .await
+        .unwrap();
+
+    let user: AliasedUser = from_row(&row).unwrap();
+
+    assert_eq!(user.id, 42);
+    assert_eq!(user.name, "Dave");
+}
+
+#[tokio::test]
+async fn test_missing_column_with_default() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct WithDefault {
+        id: i32,
+        #[facet(default)]
+        count: i32,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute("CREATE TABLE with_default (id INTEGER)", &[])
+        .await
+        .unwrap();
+
+    client
+        .execute("INSERT INTO with_default VALUES (1)", &[])
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT id FROM with_default", &[])
+        .await
+        .unwrap();
+
+    let result: WithDefault = from_row(&row).unwrap();
+
+    assert_eq!(result.id, 1);
+    assert_eq!(result.count, 0); // Default for i32
+}
+
+#[tokio::test]
+async fn test_missing_column_with_string_gets_default() {
+    // String has Default, so missing columns just get empty string
+    #[derive(Debug, Facet, PartialEq)]
+    struct WithStringDefault {
+        id: i32,
+        name: String, // Has Default, will be ""
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute("CREATE TABLE string_default (id INTEGER)", &[])
+        .await
+        .unwrap();
+
+    client
+        .execute("INSERT INTO string_default VALUES (1)", &[])
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT id FROM string_default", &[])
+        .await
+        .unwrap();
+
+    // This succeeds because String has Default
+    let result: WithStringDefault = from_row(&row).unwrap();
+    assert_eq!(result.id, 1);
+    assert_eq!(result.name, ""); // Default empty string
+}
+
+#[tokio::test]
+async fn test_type_mismatch_errors() {
+    #[derive(Debug, Facet)]
+    struct TypeMismatch {
+        id: i32,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute("CREATE TABLE type_mismatch (id TEXT)", &[])
+        .await
+        .unwrap();
+
+    client
+        .execute("INSERT INTO type_mismatch VALUES ('not a number')", &[])
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT id FROM type_mismatch", &[])
+        .await
+        .unwrap();
+
+    let result = from_row::<TypeMismatch>(&row);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("type mismatch"));
+}
+
+#[cfg(feature = "uuid")]
+#[tokio::test]
+async fn test_uuid() {
+    use uuid::Uuid;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct Product {
+        id: Uuid,
+        name: String,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute("CREATE TABLE products (id UUID, name TEXT)", &[])
+        .await
+        .unwrap();
+
+    let test_uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    client
+        .execute(
+            "INSERT INTO products (id, name) VALUES ($1::text::uuid, 'Widget')",
+            &[&test_uuid.to_string()],
+        )
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT id::text, name FROM products", &[])
+        .await
+        .unwrap();
+
+    let product: Product = from_row(&row).unwrap();
+
+    assert_eq!(product.id, test_uuid);
+    assert_eq!(product.name, "Widget");
+}
+
+#[cfg(feature = "uuid")]
+#[tokio::test]
+async fn test_optional_uuid() {
+    use uuid::Uuid;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct OptionalUuid {
+        id: i32,
+        external_id: Option<Uuid>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE optional_uuids (id INTEGER, external_id UUID)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with UUID
+    let test_uuid = Uuid::parse_str("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").unwrap();
+    client
+        .execute(
+            "INSERT INTO optional_uuids VALUES (1, $1::text::uuid)",
+            &[&test_uuid.to_string()],
+        )
+        .await
+        .unwrap();
+
+    // Insert with NULL
+    client
+        .execute("INSERT INTO optional_uuids VALUES (2, NULL)", &[])
+        .await
+        .unwrap();
+
+    let rows = client
+        .query(
+            "SELECT id, external_id::text FROM optional_uuids ORDER BY id",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let with_uuid: OptionalUuid = from_row(&rows[0]).unwrap();
+    assert_eq!(with_uuid.id, 1);
+    assert_eq!(with_uuid.external_id, Some(test_uuid));
+
+    let without_uuid: OptionalUuid = from_row(&rows[1]).unwrap();
+    assert_eq!(without_uuid.id, 2);
+    assert_eq!(without_uuid.external_id, None);
+}
+
+#[cfg(feature = "jiff02")]
+#[tokio::test]
+async fn test_timestamp() {
+    use jiff::Timestamp;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct Event {
+        id: i32,
+        created_at: Timestamp,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE events (id INTEGER, created_at TIMESTAMPTZ)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO events VALUES (1, '2024-06-19T15:22:45Z'::timestamptz)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Use native TIMESTAMPTZ deserialization (not to_char string conversion)
+    let row = client
+        .query_one("SELECT id, created_at FROM events", &[])
+        .await
+        .unwrap();
+
+    let event: Event = from_row(&row).unwrap();
+
+    assert_eq!(event.id, 1);
+    assert_eq!(event.created_at, "2024-06-19T15:22:45Z".parse().unwrap());
+}
+
+#[cfg(feature = "jiff02")]
+#[tokio::test]
+async fn test_optional_timestamp() {
+    use jiff::Timestamp;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct OptionalTimestamp {
+        id: i32,
+        deleted_at: Option<Timestamp>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE optional_timestamps (id INTEGER, deleted_at TIMESTAMPTZ)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with timestamp
+    client
+        .execute(
+            "INSERT INTO optional_timestamps VALUES (1, '2024-01-15T10:30:00Z'::timestamptz)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with NULL
+    client
+        .execute("INSERT INTO optional_timestamps VALUES (2, NULL)", &[])
+        .await
+        .unwrap();
+
+    // Use native TIMESTAMPTZ deserialization (not to_char string conversion)
+    let rows = client
+        .query(
+            "SELECT id, deleted_at FROM optional_timestamps ORDER BY id",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let with_timestamp: OptionalTimestamp = from_row(&rows[0]).unwrap();
+    assert_eq!(with_timestamp.id, 1);
+    assert_eq!(
+        with_timestamp.deleted_at,
+        Some("2024-01-15T10:30:00Z".parse().unwrap())
+    );
+
+    let without_timestamp: OptionalTimestamp = from_row(&rows[1]).unwrap();
+    assert_eq!(without_timestamp.id, 2);
+    assert_eq!(without_timestamp.deleted_at, None);
+}
+
+#[cfg(feature = "jiff02")]
+#[tokio::test]
+async fn test_civil_datetime() {
+    use jiff::civil::DateTime;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct LocalEvent {
+        id: i32,
+        scheduled_at: DateTime,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE local_events (id INTEGER, scheduled_at TIMESTAMP)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO local_events VALUES (1, '2024-06-19T15:22:45'::timestamp)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Use native TIMESTAMP deserialization (without timezone)
+    let row = client
+        .query_one("SELECT id, scheduled_at FROM local_events", &[])
+        .await
+        .unwrap();
+
+    let event: LocalEvent = from_row(&row).unwrap();
+
+    assert_eq!(event.id, 1);
+    assert_eq!(event.scheduled_at, "2024-06-19T15:22:45".parse().unwrap());
+}
+
+#[cfg(feature = "chrono")]
+#[tokio::test]
+async fn test_chrono_datetime_utc() {
+    use chrono::{DateTime, Utc};
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct ChronoEvent {
+        id: i32,
+        created_at: DateTime<Utc>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE chrono_events (id INTEGER, created_at TIMESTAMPTZ)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO chrono_events VALUES (1, '2024-06-19T15:22:45Z'::timestamptz)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one(
+            "SELECT id, to_char(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at FROM chrono_events",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let event: ChronoEvent = from_row(&row).unwrap();
+
+    assert_eq!(event.id, 1);
+    assert_eq!(
+        event.created_at,
+        "2024-06-19T15:22:45Z".parse::<DateTime<Utc>>().unwrap()
+    );
+}
+
+#[cfg(feature = "chrono")]
+#[tokio::test]
+async fn test_chrono_naive_date() {
+    use chrono::NaiveDate;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct ChronoDateRecord {
+        id: i32,
+        birth_date: NaiveDate,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE chrono_dates (id INTEGER, birth_date DATE)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO chrono_dates VALUES (1, '1990-05-15'::date)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one(
+            "SELECT id, to_char(birth_date, 'YYYY-MM-DD') as birth_date FROM chrono_dates",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let record: ChronoDateRecord = from_row(&row).unwrap();
+
+    assert_eq!(record.id, 1);
+    assert_eq!(
+        record.birth_date,
+        NaiveDate::parse_from_str("1990-05-15", "%Y-%m-%d").unwrap()
+    );
+}
+
+#[cfg(feature = "chrono")]
+#[tokio::test]
+async fn test_optional_chrono() {
+    use chrono::{DateTime, Utc};
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct OptionalChronoTimestamp {
+        id: i32,
+        updated_at: Option<DateTime<Utc>>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE optional_chrono (id INTEGER, updated_at TIMESTAMPTZ)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with timestamp
+    client
+        .execute(
+            "INSERT INTO optional_chrono VALUES (1, '2024-01-15T10:30:00Z'::timestamptz)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with NULL
+    client
+        .execute("INSERT INTO optional_chrono VALUES (2, NULL)", &[])
+        .await
+        .unwrap();
+
+    let rows = client
+        .query(
+            "SELECT id, to_char(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as updated_at FROM optional_chrono ORDER BY id",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let with_timestamp: OptionalChronoTimestamp = from_row(&rows[0]).unwrap();
+    assert_eq!(with_timestamp.id, 1);
+    assert_eq!(
+        with_timestamp.updated_at,
+        Some("2024-01-15T10:30:00Z".parse::<DateTime<Utc>>().unwrap())
+    );
+
+    let without_timestamp: OptionalChronoTimestamp = from_row(&rows[1]).unwrap();
+    assert_eq!(without_timestamp.id, 2);
+    assert_eq!(without_timestamp.updated_at, None);
+}
+
+#[cfg(feature = "time")]
+#[tokio::test]
+async fn test_time_offset_datetime() {
+    use time::OffsetDateTime;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct TimeEvent {
+        id: i32,
+        created_at: OffsetDateTime,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE time_events (id INTEGER, created_at TIMESTAMPTZ)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO time_events VALUES (1, '2024-06-19T15:22:45Z'::timestamptz)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one(
+            "SELECT id, to_char(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as created_at FROM time_events",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let event: TimeEvent = from_row(&row).unwrap();
+
+    assert_eq!(event.id, 1);
+    assert_eq!(
+        event.created_at,
+        OffsetDateTime::parse(
+            "2024-06-19T15:22:45Z",
+            &time::format_description::well_known::Rfc3339
+        )
+        .unwrap()
+    );
+}
+
+#[cfg(feature = "time")]
+#[tokio::test]
+async fn test_optional_time() {
+    use time::OffsetDateTime;
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct OptionalTimeTimestamp {
+        id: i32,
+        modified_at: Option<OffsetDateTime>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE optional_time (id INTEGER, modified_at TIMESTAMPTZ)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with timestamp
+    client
+        .execute(
+            "INSERT INTO optional_time VALUES (1, '2024-01-15T10:30:00Z'::timestamptz)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Insert with NULL
+    client
+        .execute("INSERT INTO optional_time VALUES (2, NULL)", &[])
+        .await
+        .unwrap();
+
+    let rows = client
+        .query(
+            "SELECT id, to_char(modified_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as modified_at FROM optional_time ORDER BY id",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let with_timestamp: OptionalTimeTimestamp = from_row(&rows[0]).unwrap();
+    assert_eq!(with_timestamp.id, 1);
+    assert_eq!(
+        with_timestamp.modified_at,
+        Some(
+            OffsetDateTime::parse(
+                "2024-01-15T10:30:00Z",
+                &time::format_description::well_known::Rfc3339
+            )
+            .unwrap()
+        )
+    );
+
+    let without_timestamp: OptionalTimeTimestamp = from_row(&rows[1]).unwrap();
+    assert_eq!(without_timestamp.id, 2);
+    assert_eq!(without_timestamp.modified_at, None);
+}


### PR DESCRIPTION
## Summary

- Adds `facet-tokio-postgres` crate to the dibs workspace
- This crate provides tokio-postgres Row deserialization using facet reflection
- Part of facet-rs/facet#1876

The crate now lives in dibs but still depends on `facet-core` and `facet-reflect` via git dependencies from the facet repository.

## Test plan

- [x] `cargo check -p facet-tokio-postgres` passes
- [x] Workspace builds successfully