### PR TITLE
Improve error messages for unknown columns by listing available columns

### DIFF
--- a/crates/dibs-cli/src/lints/unknown_column.rs
+++ b/crates/dibs-cli/src/lints/unknown_column.rs
@@ -10,12 +10,19 @@ pub fn lint_unknown_columns_select(select: &Select, table: &TableInfo, ctx: &mut
             continue;
         }
         if !table.columns.iter().any(|c| c.name == col_name.as_str()) {
+            let available = table
+                .columns
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
             DiagnosticBuilder::error("unknown-column")
                 .at(col_name.span)
                 .msg(format!(
-                    "Unknown column '{}' in table '{}'",
+                    "Unknown column '{}' in table '{}'. Available columns: {}",
                     col_name.as_str(),
-                    table.name
+                    table.name,
+                    available
                 ))
                 .emit(ctx.diagnostics);
         }
@@ -29,12 +36,19 @@ pub fn lint_unknown_columns_where(
 ) {
     for (col_name, _filter) in &where_clause.filters {
         if !table.columns.iter().any(|c| c.name == col_name.as_str()) {
+            let available = table
+                .columns
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
             DiagnosticBuilder::error("unknown-column")
                 .at(col_name.span)
                 .msg(format!(
-                    "Unknown column '{}' in table '{}'",
+                    "Unknown column '{}' in table '{}'. Available columns: {}",
                     col_name.as_str(),
-                    table.name
+                    table.name,
+                    available
                 ))
                 .emit(ctx.diagnostics);
         }
@@ -48,12 +62,19 @@ pub fn lint_unknown_columns_order_by(
 ) {
     for (col_name, _dir) in &order_by.columns {
         if !table.columns.iter().any(|c| c.name == col_name.as_str()) {
+            let available = table
+                .columns
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
             DiagnosticBuilder::error("unknown-column")
                 .at(col_name.span)
                 .msg(format!(
-                    "Unknown column '{}' in table '{}'",
+                    "Unknown column '{}' in table '{}'. Available columns: {}",
                     col_name.as_str(),
-                    table.name
+                    table.name,
+                    available
                 ))
                 .emit(ctx.diagnostics);
         }
@@ -63,12 +84,19 @@ pub fn lint_unknown_columns_order_by(
 pub fn lint_unknown_columns_values(values: &Values, table: &TableInfo, ctx: &mut LintContext<'_>) {
     for (col_name, _value_expr) in &values.columns {
         if !table.columns.iter().any(|c| c.name == col_name.as_str()) {
+            let available = table
+                .columns
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
             DiagnosticBuilder::error("unknown-column")
                 .at(col_name.span)
                 .msg(format!(
-                    "Unknown column '{}' in table '{}'",
+                    "Unknown column '{}' in table '{}'. Available columns: {}",
                     col_name.as_str(),
-                    table.name
+                    table.name,
+                    available
                 ))
                 .emit(ctx.diagnostics);
         }


### PR DESCRIPTION
## Summary

When the dibs query compiler reports an 'unknown-column' error, it now lists the available columns for that table. This saves time debugging and makes error messages more actionable.

## Changes

- Enhanced error messages in `lint_unknown_columns_select()`, `lint_unknown_columns_where()`, `lint_unknown_columns_order_by()`, and `lint_unknown_columns_values()` to include a comma-separated list of available columns
- Users now see errors like: `Unknown column 'id' in table 'magic_link_token'. Available columns: token, email, expires_at, used` instead of just the raw "Unknown column" message

## Testing

The changes are in the error reporting logic of the query compiler's linting phase. Existing tests should cover the basic error detection, and the enhanced message provides better UX without changing the fundamental lint behavior.

Fixes #7