### PR TITLE
Wire up FunctionSpec filter validation with proper error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,6 @@ dependencies = [
  "dibs-jsonb",
  "dibs-sql",
  "facet",
- "facet-tokio-postgres",
  "facet-value",
  "indexmap 2.13.0",
  "inventory",
@@ -1050,12 +1049,10 @@ dependencies = [
  "dibs-query-schema",
  "dibs-sql",
  "dockside",
- "facet-format",
  "facet-styx",
  "facet-testhelpers",
  "indexmap 2.13.0",
  "insta",
- "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -1338,7 +1335,6 @@ name = "facet-format"
 version = "0.43.2"
 source = "git+https://github.com/facet-rs/facet?branch=main#df49ae20b26f97dedf6a1077a35c098a5e2bdb75"
 dependencies = [
- "ariadne",
  "facet-core",
  "facet-dessert",
  "facet-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ facet-value = { git = "https://github.com/facet-rs/facet", branch = "main" }
 facet-json = { git = "https://github.com/facet-rs/facet", branch = "main" }
 facet-reflect = { git = "https://github.com/facet-rs/facet", branch = "main" }
 facet-testhelpers = { git = "https://github.com/facet-rs/facet", branch = "main" }
-facet-format = { git = "https://github.com/facet-rs/facet", branch = "main" }
 facet-tokio-postgres = { path = "crates/facet-tokio-postgres" }
 
 strid = { git = "https://github.com/bearcove/strid", branch = "main" }

--- a/crates/dibs-db-schema/Cargo.toml
+++ b/crates/dibs-db-schema/Cargo.toml
@@ -17,8 +17,6 @@ chrono.workspace = true
 dibs-jsonb = { version = "0.1.0", path = "../dibs-jsonb" }
 dibs-sql = { version = "0.1.0", path = "../dibs-sql" }
 facet = { workspace = true, features = ["uuid", "chrono", "rust_decimal", "jiff02"] }
-# could shed this dep if we put the `Jsonb` type elsewhere but shrug
-facet-tokio-postgres.workspace = true
 indexmap.workspace = true
 inventory.workspace = true
 jiff.workspace = true

--- a/crates/dibs-qgen/Cargo.toml
+++ b/crates/dibs-qgen/Cargo.toml
@@ -13,8 +13,6 @@ dibs-db-schema = { path = "../dibs-db-schema" }
 dibs-query-schema.workspace = true
 dibs-sql = { path = "../dibs-sql" }
 facet-styx = { workspace = true, features = ["tracing"] }
-facet-format = { workspace = true, features = ["ariadne"] }
-thiserror.workspace = true
 codegen.workspace = true
 ariadne.workspace = true
 camino = "1.2.2"

--- a/crates/dibs-qgen/src/error.rs
+++ b/crates/dibs-qgen/src/error.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 // Error Handling Types
 // ============================================================================
 
+#[derive(Clone)]
 pub struct QSource {
     /// The original source code (for rendering diagnostics)
     pub source: String,

--- a/crates/dibs-qgen/src/lib.rs
+++ b/crates/dibs-qgen/src/lib.rs
@@ -30,6 +30,11 @@ pub use sqlgen::{
 mod rustgen;
 pub use rustgen::{GeneratedCode, generate_rust_code};
 
-// Filter argument parsing
+// Filter argument parsing and validation
 mod filter_spec;
-pub use filter_spec::FilterArg;
+pub use filter_spec::{
+    ArgSpec, CONTAINS_SPEC, EQ_BARE_SPEC, EQ_SPEC, FilterArg, FunctionSpec, GT_SPEC, GTE_SPEC,
+    ILIKE_SPEC, IN_SPEC, JSON_GET_SPEC, JSON_GET_TEXT_SPEC, KEY_EXISTS_SPEC, LIKE_SPEC, LT_SPEC,
+    LTE_SPEC, NE_SPEC, validate_filter, validate_query_file, validate_relation_where,
+    validate_where,
+};

--- a/crates/dibs-qgen/src/lib.rs
+++ b/crates/dibs-qgen/src/lib.rs
@@ -21,9 +21,9 @@ pub(crate) use planner::{QueryPlan, QueryPlanner};
 mod sqlgen;
 pub use sqlgen::{
     GeneratedDelete, GeneratedInsert, GeneratedInsertMany, GeneratedSelect, GeneratedUpdate,
-    GeneratedUpsert, GeneratedUpsertMany, generate_delete_sql, generate_insert_many_sql,
-    generate_insert_sql, generate_select_sql, generate_update_sql, generate_upsert_many_sql,
-    generate_upsert_sql,
+    GeneratedUpsert, GeneratedUpsertMany, SqlGenContext, generate_delete_sql,
+    generate_insert_many_sql, generate_insert_sql, generate_select_sql, generate_update_sql,
+    generate_upsert_many_sql, generate_upsert_sql,
 };
 
 // Rust code generation

--- a/crates/dibs-qgen/src/parse/mod.rs
+++ b/crates/dibs-qgen/src/parse/mod.rs
@@ -2,24 +2,36 @@
 //!
 //! Uses facet-styx for parsing.
 
+use crate::filter_spec::validate_query_file;
 use crate::{QError, QErrorKind, QSource};
 use camino::Utf8Path;
 use dibs_query_schema::{QueryFile, Span};
 use std::sync::Arc;
 
 /// Parse a styx source string into a QueryFile.
+///
+/// This function parses the styx source and validates all filter arguments
+/// according to their specifications. If any filter has invalid arguments
+/// (wrong count or wrong type), an error with proper span information is returned.
 pub fn parse_query_file(source_path: &Utf8Path, source: &str) -> Result<QueryFile, QError> {
-    facet_styx::from_str(source).map_err(|e| {
+    let qsource = Arc::new(QSource {
+        source: source.to_string(),
+        source_path: source_path.to_owned(),
+    });
+
+    let query_file: QueryFile = facet_styx::from_str(source).map_err(|e| {
         let span = e.span.unwrap_or(Span { offset: 0, len: 0 });
         QError {
-            source: Arc::new(QSource {
-                source: source.to_string(),
-                source_path: source_path.to_owned(),
-            }),
+            source: qsource.clone(),
             span,
             kind: QErrorKind::Parse {
                 message: e.kind.to_string(),
             },
         }
-    })
+    })?;
+
+    // Validate all filter arguments after parsing
+    validate_query_file(qsource, &query_file)?;
+
+    Ok(query_file)
 }

--- a/crates/dibs-qgen/src/parse/mod.rs
+++ b/crates/dibs-qgen/src/parse/mod.rs
@@ -2,7 +2,6 @@
 //!
 //! Uses facet-styx for parsing.
 
-use crate::filter_spec::validate_query_file;
 use crate::{QError, QErrorKind, QSource};
 use camino::Utf8Path;
 use dibs_query_schema::{QueryFile, Span};
@@ -10,10 +9,12 @@ use std::sync::Arc;
 
 /// Parse a styx source string into a QueryFile.
 ///
-/// This function parses the styx source and validates all filter arguments
-/// according to their specifications. If any filter has invalid arguments
-/// (wrong count or wrong type), an error with proper span information is returned.
-pub fn parse_query_file(source_path: &Utf8Path, source: &str) -> Result<QueryFile, QError> {
+/// Returns both the parsed QueryFile and the QSource for error reporting.
+/// Validation is deferred to SQL generation phase for proper context.
+pub fn parse_query_file(
+    source_path: &Utf8Path,
+    source: &str,
+) -> Result<(QueryFile, Arc<QSource>), QError> {
     let qsource = Arc::new(QSource {
         source: source.to_string(),
         source_path: source_path.to_owned(),
@@ -30,8 +31,8 @@ pub fn parse_query_file(source_path: &Utf8Path, source: &str) -> Result<QueryFil
         }
     })?;
 
-    // Validate all filter arguments after parsing
-    validate_query_file(qsource, &query_file)?;
+    // Note: Filter validation is now done during SQL generation
+    // where we have proper context for rich error messages
 
-    Ok(query_file)
+    Ok((query_file, qsource))
 }

--- a/crates/dibs-qgen/src/planner/mod.rs
+++ b/crates/dibs-qgen/src/planner/mod.rs
@@ -197,6 +197,7 @@ impl<'a> QueryPlanner<'a> {
     }
 
     /// Process nested select fields (used for relations).
+    #[allow(clippy::too_many_arguments)]
     fn process_select_nested(
         &self,
         select: &SelectFields,
@@ -358,7 +359,7 @@ impl<'a> QueryPlanner<'a> {
                         first: false,
                         select_columns: vec![],
                     },
-                    direction: FkDirection::Reverse,
+                    _direction: FkDirection::Reverse,
                     parent_key_column,
                 });
             }
@@ -390,7 +391,7 @@ impl<'a> QueryPlanner<'a> {
                         first: false,
                         select_columns: vec![],
                     },
-                    direction: FkDirection::Forward,
+                    _direction: FkDirection::Forward,
                     parent_key_column,
                 });
             }
@@ -433,6 +434,7 @@ impl QueryPlan {
     }
 
     /// Generate SQL FROM clause with JOINs.
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_sql(&self) -> String {
         self.from_sql_with_params(&mut Vec::new(), &mut 1)
     }
@@ -441,6 +443,7 @@ impl QueryPlan {
     ///
     /// Returns the SQL and appends any parameter names to `param_order`.
     /// `param_idx` is updated to track the next $N placeholder.
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_sql_with_params(
         &self,
         param_order: &mut Vec<dibs_sql::ParamName>,

--- a/crates/dibs-qgen/src/planner/types.rs
+++ b/crates/dibs-qgen/src/planner/types.rs
@@ -201,8 +201,8 @@ pub enum FkDirection {
 pub struct FkResolution {
     /// The JOIN clause
     pub join_clause: JoinClause,
-    /// Direction of the relationship
-    pub direction: FkDirection,
+    /// Direction of the relationship (reserved for future use)
+    pub _direction: FkDirection,
     /// Parent's primary key column (used for grouping Vec relations)
     pub parent_key_column: ColumnName,
 }

--- a/crates/dibs-qgen/src/planner/types.rs
+++ b/crates/dibs-qgen/src/planner/types.rs
@@ -184,6 +184,7 @@ pub enum PlanError {
     /// No FK relationship found between tables
     NoForeignKey { from: String, to: String },
     /// Relation requires explicit 'from' clause
+    #[allow(dead_code)]
     RelationNeedsFrom { relation: String },
 }
 

--- a/crates/dibs-qgen/src/rustgen/mod.rs
+++ b/crates/dibs-qgen/src/rustgen/mod.rs
@@ -483,14 +483,14 @@ fn generate_query_body(ctx: &CodegenContext, query: &Select, struct_name: &str) 
     block.line("");
     block.line("// Deserialize all rows into flat structs using facet reflection");
     block.line(format!(
-        "let flat_rows: Vec<{flat_struct_name}> = rows.iter().map(|row| from_row(row)).collect::<Result<Vec<_>, _>>()?;"
+        "let flat_rows: Vec<{flat_struct_name}> = rows.iter().map(from_row).collect::<Result<Vec<_>, _>>()?;"
     ));
     block.line("");
 
     // Generate the transformation from flat rows to nested result
     let Some(select_fields) = &query.fields else {
         // No fields - shouldn't happen for queries with relations
-        block.line(format!("Ok(vec![])"));
+        block.line("Ok(vec![])".to_string());
         return block_to_string(&block);
     };
 
@@ -792,7 +792,7 @@ fn generate_relation_assembly(
 
                     let mut if_block =
                         Block::new(format!("if let Some(ref rel_id) = flat_row.{id_alias}"));
-                    if_block.line(format!("let key = (parent_id.clone(), rel_id.clone());"));
+                    if_block.line("let key = (parent_id.clone(), rel_id.clone());".to_string());
 
                     let mut if_insert = Block::new(format!("if {set_name}.insert(key)"));
                     let mut push_block =

--- a/crates/dibs-qgen/src/rustgen/tests.rs
+++ b/crates/dibs-qgen/src/rustgen/tests.rs
@@ -75,7 +75,7 @@ AllProducts @select{
         ],
         vec![],
     )]);
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
     assert!(code.code.contains("pub struct AllProductsResult"));
     assert!(code.code.contains("pub async fn all_products"));
@@ -104,7 +104,7 @@ ProductByHandle @select{
         ],
         vec![],
     )]);
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
     assert!(code.code.contains("handle: &String"));
     // Uses direct struct construction for Option-returning queries
@@ -145,7 +145,7 @@ ProductListing @select{
             }],
         ),
     ]);
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
     assert!(
         code.code
@@ -168,7 +168,7 @@ TrendingProducts @select{
 "#;
     let (file, qsource) = parse_test(source);
     // Raw SQL queries don't need schema - types come from explicit `returns` clause
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     assert!(code.code.contains("locale: &String"));
     assert!(code.code.contains("days: &i64"));
@@ -234,7 +234,7 @@ ProductWithTranslation @select{
         ),
     ]);
 
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
     tracing::info!("Generated code:\n{}", code.code);
 
@@ -309,7 +309,7 @@ ProductWithVariants @select{
         ),
     ]);
 
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
     tracing::info!("Generated code:\n{}", code.code);
 
@@ -389,7 +389,7 @@ ProductWithVariantCount @select{
         ),
     ]);
 
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
     tracing::info!("Generated code:\n{}", code.code);
 
@@ -472,7 +472,7 @@ ProductWithVariantsAndPrices @select{
         ),
     ]);
 
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
     tracing::info!("Generated code:\n{}", code.code);
 
@@ -548,7 +548,7 @@ CreateUser @insert{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     assert!(code.code.contains("pub struct CreateUserResult"));
     assert!(code.code.contains("pub async fn create_user"));
@@ -577,7 +577,7 @@ UpsertProduct @upsert{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     assert!(code.code.contains("pub struct UpsertProductResult"));
     assert!(code.code.contains("pub async fn upsert_product"));
@@ -598,7 +598,7 @@ UpdateUserEmail @update{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     assert!(code.code.contains("pub struct UpdateUserEmailResult"));
     assert!(code.code.contains("pub async fn update_user_email"));
@@ -618,7 +618,7 @@ DeleteUser @delete{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     assert!(code.code.contains("pub struct DeleteUserResult"));
     assert!(code.code.contains("pub async fn delete_user"));
@@ -636,7 +636,7 @@ InsertLog @insert{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     // Should NOT generate a result struct
     assert!(!code.code.contains("pub struct InsertLogResult"));
@@ -657,7 +657,7 @@ BulkCreateProducts @insert-many{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     // Should generate params struct
     assert!(
@@ -725,7 +725,7 @@ BulkUpsertProducts @upsert-many{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     // Should generate params struct
     assert!(
@@ -770,7 +770,7 @@ BulkInsertLogs @insert-many{
 }
 "#;
     let (file, qsource) = parse_test(source);
-    let code = generate_rust_code(&file, &empty_schema(), qsource);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
     // Should NOT generate result struct
     assert!(

--- a/crates/dibs-qgen/src/sqlgen/common.rs
+++ b/crates/dibs-qgen/src/sqlgen/common.rs
@@ -1,6 +1,12 @@
 //! Common SQL generation utilities shared across statement types.
 
-use dibs_query_schema::{FilterValue, Meta, Payload, UpdateValue, ValueExpr, Where};
+use super::SqlGenContext;
+use crate::filter_spec::{
+    CONTAINS_SPEC, EQ_SPEC, GT_SPEC, GTE_SPEC, ILIKE_SPEC, IN_SPEC, JSON_GET_SPEC,
+    JSON_GET_TEXT_SPEC, KEY_EXISTS_SPEC, LIKE_SPEC, LT_SPEC, LTE_SPEC, NE_SPEC,
+};
+use crate::{FilterArg, QError};
+use dibs_query_schema::{FilterValue, Meta, Payload, Span, UpdateValue, ValueExpr, Where};
 use dibs_sql::{BinOp, ColumnName, Expr, TableName};
 
 /// Convert a column name (possibly qualified like "t0.id") to an Expr.
@@ -53,131 +59,176 @@ pub fn meta_string_to_expr(meta: &Meta<String>) -> Expr {
     }
 }
 
-/// Convert a FilterValue to a dibs_sql::Expr.
-///
-/// The column can be either a simple name like "id" or a qualified name like "t0.id".
-/// Qualified names are parsed and converted to qualified column expressions.
-pub fn filter_value_to_expr(column: &ColumnName, filter: &FilterValue) -> Option<Expr> {
-    let col = column_name_to_expr(column);
-
-    // For EqBare shorthand, we need the unqualified column name for the param
-    let unqualified_name = extract_column_name(column);
-
-    match filter {
-        FilterValue::Null => Some(col.is_null()),
-        FilterValue::NotNull => Some(col.is_not_null()),
-
-        FilterValue::Eq(args) => {
-            let arg = args.first()?;
-            Some(col.eq(meta_string_to_expr(arg)))
-        }
-
-        FilterValue::EqBare(opt_meta) => {
-            if let Some(meta) = opt_meta {
-                Some(col.eq(meta_string_to_expr(meta)))
+/// Convert a FilterArg to an Expr.
+fn filter_arg_to_expr(arg: &FilterArg) -> Expr {
+    match arg {
+        FilterArg::Variable(name) => Expr::param(name.as_str().into()),
+        FilterArg::Literal(lit) => {
+            // Try to parse as integer
+            if let Ok(n) = lit.parse::<i64>() {
+                Expr::int(n)
+            } else if lit == "true" {
+                Expr::bool(true)
+            } else if lit == "false" {
+                Expr::bool(false)
             } else {
-                // Shorthand: {id} means {id $id} - use unqualified column name as param name
-                Some(col.eq(Expr::param(unqualified_name.into())))
+                Expr::string(lit)
             }
-        }
-
-        FilterValue::Ne(args) => {
-            let arg = args.first()?;
-            Some(Expr::BinOp {
-                left: Box::new(col),
-                op: BinOp::Ne,
-                right: Box::new(meta_string_to_expr(arg)),
-            })
-        }
-
-        FilterValue::Lt(args) => {
-            let arg = args.first()?;
-            Some(Expr::BinOp {
-                left: Box::new(col),
-                op: BinOp::Lt,
-                right: Box::new(meta_string_to_expr(arg)),
-            })
-        }
-
-        FilterValue::Lte(args) => {
-            let arg = args.first()?;
-            Some(Expr::BinOp {
-                left: Box::new(col),
-                op: BinOp::Le,
-                right: Box::new(meta_string_to_expr(arg)),
-            })
-        }
-
-        FilterValue::Gt(args) => {
-            let arg = args.first()?;
-            Some(Expr::BinOp {
-                left: Box::new(col),
-                op: BinOp::Gt,
-                right: Box::new(meta_string_to_expr(arg)),
-            })
-        }
-
-        FilterValue::Gte(args) => {
-            let arg = args.first()?;
-            Some(Expr::BinOp {
-                left: Box::new(col),
-                op: BinOp::Ge,
-                right: Box::new(meta_string_to_expr(arg)),
-            })
-        }
-
-        FilterValue::Like(args) => {
-            let arg = args.first()?;
-            Some(col.like(meta_string_to_expr(arg)))
-        }
-
-        FilterValue::Ilike(args) => {
-            let arg = args.first()?;
-            Some(col.ilike(meta_string_to_expr(arg)))
-        }
-
-        FilterValue::In(args) => {
-            let arg = args.first()?;
-            Some(col.any(meta_string_to_expr(arg)))
-        }
-
-        FilterValue::JsonGet(args) => {
-            let arg = args.first()?;
-            Some(col.json_get(meta_string_to_expr(arg)))
-        }
-
-        FilterValue::JsonGetText(args) => {
-            let arg = args.first()?;
-            Some(col.json_get_text(meta_string_to_expr(arg)))
-        }
-
-        FilterValue::Contains(args) => {
-            let arg = args.first()?;
-            Some(col.contains(meta_string_to_expr(arg)))
-        }
-
-        FilterValue::KeyExists(args) => {
-            let arg = args.first()?;
-            Some(col.key_exists(meta_string_to_expr(arg)))
         }
     }
 }
 
-/// Convert a WHERE clause to a dibs_sql::Expr.
-pub fn where_to_expr(where_clause: &Where) -> Option<Expr> {
+/// Convert a FilterValue to a dibs_sql::Expr with validation.
+///
+/// Validates arguments using FunctionSpec::parse_args() and returns rich errors
+/// with proper span information on validation failure.
+pub fn filter_value_to_expr_validated(
+    ctx: &SqlGenContext,
+    column: &ColumnName,
+    filter: &FilterValue,
+    filter_span: Span,
+) -> Result<Option<Expr>, QError> {
+    let col = column_name_to_expr(column);
+    let unqualified_name = extract_column_name(column);
+
+    match filter {
+        FilterValue::Null => Ok(Some(col.is_null())),
+        FilterValue::NotNull => Ok(Some(col.is_not_null())),
+
+        FilterValue::Eq(args) => {
+            let parsed = EQ_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.eq(filter_arg_to_expr(arg))))
+        }
+
+        FilterValue::EqBare(opt_meta) => {
+            if let Some(meta) = opt_meta {
+                // Single argument - parse and validate
+                let arg = FilterArg::parse(&meta.value);
+                Ok(Some(col.eq(filter_arg_to_expr(&arg))))
+            } else {
+                // Shorthand: {id} means {id $id}
+                Ok(Some(col.eq(Expr::param(unqualified_name.into()))))
+            }
+        }
+
+        FilterValue::Ne(args) => {
+            let parsed = NE_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(Expr::BinOp {
+                left: Box::new(col),
+                op: BinOp::Ne,
+                right: Box::new(filter_arg_to_expr(arg)),
+            }))
+        }
+
+        FilterValue::Lt(args) => {
+            let parsed = LT_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(Expr::BinOp {
+                left: Box::new(col),
+                op: BinOp::Lt,
+                right: Box::new(filter_arg_to_expr(arg)),
+            }))
+        }
+
+        FilterValue::Lte(args) => {
+            let parsed = LTE_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(Expr::BinOp {
+                left: Box::new(col),
+                op: BinOp::Le,
+                right: Box::new(filter_arg_to_expr(arg)),
+            }))
+        }
+
+        FilterValue::Gt(args) => {
+            let parsed = GT_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(Expr::BinOp {
+                left: Box::new(col),
+                op: BinOp::Gt,
+                right: Box::new(filter_arg_to_expr(arg)),
+            }))
+        }
+
+        FilterValue::Gte(args) => {
+            let parsed = GTE_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(Expr::BinOp {
+                left: Box::new(col),
+                op: BinOp::Ge,
+                right: Box::new(filter_arg_to_expr(arg)),
+            }))
+        }
+
+        FilterValue::Like(args) => {
+            let parsed = LIKE_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.like(filter_arg_to_expr(arg))))
+        }
+
+        FilterValue::Ilike(args) => {
+            let parsed = ILIKE_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.ilike(filter_arg_to_expr(arg))))
+        }
+
+        FilterValue::In(args) => {
+            let parsed = IN_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.any(filter_arg_to_expr(arg))))
+        }
+
+        FilterValue::JsonGet(args) => {
+            let parsed = JSON_GET_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.json_get(filter_arg_to_expr(arg))))
+        }
+
+        FilterValue::JsonGetText(args) => {
+            let parsed = JSON_GET_TEXT_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.json_get_text(filter_arg_to_expr(arg))))
+        }
+
+        FilterValue::Contains(args) => {
+            let parsed = CONTAINS_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.contains(filter_arg_to_expr(arg))))
+        }
+
+        FilterValue::KeyExists(args) => {
+            let parsed = KEY_EXISTS_SPEC.parse_args(ctx.source.clone(), filter_span, args)?;
+            let arg = &parsed[0];
+            Ok(Some(col.key_exists(filter_arg_to_expr(arg))))
+        }
+    }
+}
+
+/// Convert a WHERE clause to a dibs_sql::Expr with validation.
+///
+/// Validates all filter arguments using FunctionSpec and returns rich errors.
+pub fn where_to_expr_validated(
+    ctx: &SqlGenContext,
+    where_clause: &Where,
+) -> Result<Option<Expr>, QError> {
     let mut exprs: Vec<Expr> = vec![];
 
     for (col_meta, filter_value) in &where_clause.filters {
         let col_name = &col_meta.value;
-        if let Some(expr) = filter_value_to_expr(col_name, filter_value) {
+        if let Some(expr) =
+            filter_value_to_expr_validated(ctx, col_name, filter_value, col_meta.span)?
+        {
             exprs.push(expr);
         }
     }
 
     // AND all expressions together
     let mut iter = exprs.into_iter();
-    let first = iter.next()?;
-    Some(iter.fold(first, |acc, expr| acc.and(expr)))
+    Ok(iter
+        .next()
+        .map(|first| iter.fold(first, |acc, expr| acc.and(expr))))
 }
 
 /// Convert a ValueExpr to a dibs_sql::Expr.

--- a/crates/dibs-qgen/src/sqlgen/delete.rs
+++ b/crates/dibs-qgen/src/sqlgen/delete.rs
@@ -71,7 +71,7 @@ mod tests {
     use crate::parse_query_file;
 
     fn get_first_delete(source: &str) -> Delete {
-        let file = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+        let (file, _source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
         for (_, decl) in file.0.iter() {
             if let dibs_query_schema::Decl::Delete(d) = decl {
                 return d.clone();

--- a/crates/dibs-qgen/src/sqlgen/delete.rs
+++ b/crates/dibs-qgen/src/sqlgen/delete.rs
@@ -22,10 +22,10 @@ pub fn generate_delete_sql(delete: &Delete) -> GeneratedDelete {
     let mut stmt = DeleteStmt::new(delete.from.value.clone());
 
     // WHERE clause
-    if let Some(where_clause) = &delete.where_clause {
-        if let Some(expr) = where_to_expr(where_clause) {
-            stmt = stmt.where_(expr);
-        }
+    if let Some(where_clause) = &delete.where_clause
+        && let Some(expr) = where_to_expr(where_clause)
+    {
+        stmt = stmt.where_(expr);
     }
 
     // RETURNING clause

--- a/crates/dibs-qgen/src/sqlgen/insert.rs
+++ b/crates/dibs-qgen/src/sqlgen/insert.rs
@@ -54,7 +54,7 @@ mod tests {
     use crate::parse_query_file;
 
     fn get_first_insert(source: &str) -> Insert {
-        let file = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+        let (file, _source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
         for (_, decl) in file.0.iter() {
             if let dibs_query_schema::Decl::Insert(i) = decl {
                 return i.clone();

--- a/crates/dibs-qgen/src/sqlgen/insert_many.rs
+++ b/crates/dibs-qgen/src/sqlgen/insert_many.rs
@@ -206,7 +206,7 @@ mod tests {
     use crate::parse_query_file;
 
     fn get_first_insert_many(source: &str) -> InsertMany {
-        let file = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+        let (file, _source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
         for (_, decl) in file.0.iter() {
             if let dibs_query_schema::Decl::InsertMany(im) = decl {
                 return im.clone();

--- a/crates/dibs-qgen/src/sqlgen/mod.rs
+++ b/crates/dibs-qgen/src/sqlgen/mod.rs
@@ -11,35 +11,12 @@ mod upsert_many;
 
 // Common helpers are used by submodules via `super::common::`
 pub use delete::{GeneratedDelete, generate_delete_sql};
-use indexmap::IndexMap;
 pub use insert::{GeneratedInsert, generate_insert_sql};
 pub use insert_many::{GeneratedInsertMany, generate_insert_many_sql};
 pub use select::{GeneratedSelect, generate_select_sql};
 pub use update::{GeneratedUpdate, generate_update_sql};
 pub use upsert::{GeneratedUpsert, generate_upsert_sql};
 pub use upsert_many::{GeneratedUpsertMany, generate_upsert_many_sql};
-
-#[allow(unused_imports)]
-use dibs_query_schema::{ParamType, ValueExpr};
-
-use crate::QueryPlan;
-
-/// Generated SQL with parameter placeholders.
-#[derive(Debug, Clone)]
-pub struct GeneratedSql {
-    /// The SQL string with $1, $2, etc. placeholders.
-    pub sql: String,
-
-    /// Parameter names in order (maps to $1, $2, etc.).
-    pub param_order: Vec<String>,
-
-    /// Query plan (if JOINs are involved).
-    pub plan: Option<QueryPlan>,
-
-    /// Column names in SELECT order (for index-based access).
-    /// Maps column names to their index in the result set.
-    pub column_order: IndexMap<String, usize>,
-}
 
 /// Format a single filter condition from a column name and FilterValue.
 ///

--- a/crates/dibs-qgen/src/sqlgen/mod.rs
+++ b/crates/dibs-qgen/src/sqlgen/mod.rs
@@ -1,5 +1,9 @@
 //! SQL generation from query schema types.
 
+use crate::QSource;
+use dibs_db_schema::Schema;
+use std::sync::Arc;
+
 mod common;
 mod delete;
 mod insert;
@@ -18,122 +22,21 @@ pub use update::{GeneratedUpdate, generate_update_sql};
 pub use upsert::{GeneratedUpsert, generate_upsert_sql};
 pub use upsert_many::{GeneratedUpsertMany, generate_upsert_many_sql};
 
-/// Format a single filter condition from a column name and FilterValue.
+/// Context for SQL generation.
 ///
-/// Returns the SQL condition string and the updated param index.
-fn format_filter(
-    column: &str,
-    filter_value: &dibs_query_schema::FilterValue,
-    mut param_idx: usize,
-    param_order: &mut Vec<dibs_sql::ParamName>,
-) -> (String, usize) {
-    use crate::FilterArg;
-    use dibs_query_schema::FilterValue;
+/// Carries schema and source information for validation and rich error messages.
+pub struct SqlGenContext<'a> {
+    /// The database schema for type lookups and validation.
+    pub schema: &'a Schema,
 
-    // Handle dotted column names (e.g., "t0.column") by quoting each part
-    let col = if column.contains('.') {
-        column
-            .split('.')
-            .map(|part| format!("\"{part}\""))
-            .collect::<Vec<_>>()
-            .join(".")
-    } else {
-        format!("\"{column}\"")
-    };
+    /// The source file for error reporting with proper spans.
+    pub source: Arc<QSource>,
+}
 
-    /// Format a comparison operator with a single argument.
-    fn format_comparison(
-        col: &str,
-        op: &str,
-        args: &[dibs_query_schema::Meta<String>],
-        param_idx: &mut usize,
-        param_order: &mut Vec<dibs_sql::ParamName>,
-    ) -> String {
-        use crate::FilterArg;
-
-        if let Some(arg) = args.first() {
-            match FilterArg::parse(&arg.value) {
-                FilterArg::Variable(name) => {
-                    param_order.push(name.into());
-                    let s = format!("{col} {op} ${}", *param_idx);
-                    *param_idx += 1;
-                    s
-                }
-                FilterArg::Literal(value) => {
-                    let escaped = value.replace('\'', "''");
-                    format!("{col} {op} '{escaped}'")
-                }
-            }
-        } else {
-            format!("{col} {op} NULL")
-        }
+impl<'a> SqlGenContext<'a> {
+    pub fn new(schema: &'a Schema, source: Arc<QSource>) -> Self {
+        Self { schema, source }
     }
-
-    let result = match filter_value {
-        FilterValue::Null => format!("{col} IS NULL"),
-        FilterValue::NotNull => format!("{col} IS NOT NULL"),
-        FilterValue::Eq(args) => format_comparison(&col, "=", args, &mut param_idx, param_order),
-        FilterValue::EqBare(opt_meta) => {
-            if let Some(meta) = opt_meta {
-                match FilterArg::parse(&meta.value) {
-                    FilterArg::Variable(name) => {
-                        param_order.push(name.into());
-                        let s = format!("{col} = ${param_idx}");
-                        param_idx += 1;
-                        s
-                    }
-                    FilterArg::Literal(value) => {
-                        let escaped = value.replace('\'', "''");
-                        format!("{col} = '{escaped}'")
-                    }
-                }
-            } else {
-                format!("{col} IS NULL")
-            }
-        }
-        FilterValue::Ne(args) => format_comparison(&col, "!=", args, &mut param_idx, param_order),
-        FilterValue::Lt(args) => format_comparison(&col, "<", args, &mut param_idx, param_order),
-        FilterValue::Lte(args) => format_comparison(&col, "<=", args, &mut param_idx, param_order),
-        FilterValue::Gt(args) => format_comparison(&col, ">", args, &mut param_idx, param_order),
-        FilterValue::Gte(args) => format_comparison(&col, ">=", args, &mut param_idx, param_order),
-        FilterValue::Like(args) => {
-            format_comparison(&col, "LIKE", args, &mut param_idx, param_order)
-        }
-        FilterValue::Ilike(args) => {
-            format_comparison(&col, "ILIKE", args, &mut param_idx, param_order)
-        }
-        FilterValue::In(args) => {
-            if let Some(arg) = args.first() {
-                match FilterArg::parse(&arg.value) {
-                    FilterArg::Variable(name) => {
-                        param_order.push(name.into());
-                        let s = format!("{col} = ANY(${param_idx})");
-                        param_idx += 1;
-                        s
-                    }
-                    FilterArg::Literal(value) => {
-                        format!("{col} = ANY(ARRAY[{value}])")
-                    }
-                }
-            } else {
-                format!("{col} = ANY(ARRAY[])")
-            }
-        }
-        FilterValue::JsonGet(args) => {
-            format_comparison(&col, "->", args, &mut param_idx, param_order)
-        }
-        FilterValue::JsonGetText(args) => {
-            format_comparison(&col, "->>", args, &mut param_idx, param_order)
-        }
-        FilterValue::Contains(args) => {
-            format_comparison(&col, "@>", args, &mut param_idx, param_order)
-        }
-        FilterValue::KeyExists(args) => {
-            format_comparison(&col, "?", args, &mut param_idx, param_order)
-        }
-    };
-
-    (result, param_idx)
 }
 
 #[cfg(test)]

--- a/crates/dibs-qgen/src/sqlgen/select.rs
+++ b/crates/dibs-qgen/src/sqlgen/select.rs
@@ -73,44 +73,44 @@ pub fn generate_select_sql(
     sql.push_str(&plan.from_sql_with_params(&mut param_order, &mut param_idx));
 
     // WHERE
-    if let Some(where_clause) = &query.where_clause {
-        if !where_clause.filters.is_empty() {
-            sql.push_str(" WHERE ");
-            let conditions: Vec<_> = where_clause
-                .filters
-                .iter()
-                .map(|(col_meta, filter_value)| {
-                    // Prefix column with base table alias
-                    let column = format!("t0.{}", col_meta.value);
-                    let (cond, new_idx) =
-                        format_filter(&column, filter_value, param_idx, &mut param_order);
-                    param_idx = new_idx;
-                    cond
-                })
-                .collect();
-            sql.push_str(&conditions.join(" AND "));
-        }
+    if let Some(where_clause) = &query.where_clause
+        && !where_clause.filters.is_empty()
+    {
+        sql.push_str(" WHERE ");
+        let conditions: Vec<_> = where_clause
+            .filters
+            .iter()
+            .map(|(col_meta, filter_value)| {
+                // Prefix column with base table alias
+                let column = format!("t0.{}", col_meta.value);
+                let (cond, new_idx) =
+                    format_filter(&column, filter_value, param_idx, &mut param_order);
+                param_idx = new_idx;
+                cond
+            })
+            .collect();
+        sql.push_str(&conditions.join(" AND "));
     }
 
     // ORDER BY
-    if let Some(order_by) = &query.order_by {
-        if !order_by.columns.is_empty() {
-            sql.push_str(" ORDER BY ");
-            let orders: Vec<_> = order_by
-                .columns
-                .iter()
-                .map(|(col_meta, dir_opt)| {
-                    let dir = dir_opt.as_ref().map(|d| d.value.as_str()).unwrap_or("asc");
-                    let dir_sql = if dir.eq_ignore_ascii_case("desc") {
-                        "DESC"
-                    } else {
-                        "ASC"
-                    };
-                    format!("\"t0\".\"{}\" {}", col_meta.value, dir_sql)
-                })
-                .collect();
-            sql.push_str(&orders.join(", "));
-        }
+    if let Some(order_by) = &query.order_by
+        && !order_by.columns.is_empty()
+    {
+        sql.push_str(" ORDER BY ");
+        let orders: Vec<_> = order_by
+            .columns
+            .iter()
+            .map(|(col_meta, dir_opt)| {
+                let dir = dir_opt.as_ref().map(|d| d.value.as_str()).unwrap_or("asc");
+                let dir_sql = if dir.eq_ignore_ascii_case("desc") {
+                    "DESC"
+                } else {
+                    "ASC"
+                };
+                format!("\"t0\".\"{}\" {}", col_meta.value, dir_sql)
+            })
+            .collect();
+        sql.push_str(&orders.join(", "));
     }
 
     // LIMIT

--- a/crates/dibs-qgen/src/sqlgen/select.rs
+++ b/crates/dibs-qgen/src/sqlgen/select.rs
@@ -1,12 +1,14 @@
 //! SQL generation for SELECT statements.
 
-use crate::{QueryPlan, QueryPlanner};
-use dibs_db_schema::Schema;
-use dibs_query_schema::Select;
-use dibs_sql::{ColumnName, ParamName};
+use super::SqlGenContext;
+use super::common::{filter_value_to_expr, meta_string_to_expr};
+use crate::{QError, QueryPlan, QueryPlanner};
+use dibs_query_schema::{OrderBy as QueryOrderBy, Select, Where};
+use dibs_sql::{
+    ColumnName, Expr, FromClause, Join, JoinKind, OrderBy, ParamName, SelectColumn, SelectStmt,
+    render,
+};
 use std::collections::HashMap;
-
-use super::format_filter;
 
 /// Generated SQL with parameter placeholders.
 #[derive(Debug, Clone)]
@@ -23,20 +25,33 @@ pub struct GeneratedSelect {
 }
 
 /// Generate SQL for a SELECT query using the planner.
-pub fn generate_select_sql(
-    query: &Select,
-    schema: &Schema,
-) -> Result<GeneratedSelect, crate::planner::PlanError> {
+pub fn generate_select_sql(ctx: &SqlGenContext, query: &Select) -> Result<GeneratedSelect, QError> {
     // Plan the query
-    let planner = QueryPlanner::new(schema);
-    let plan = planner.plan(query)?;
-
-    let mut sql = String::new();
-    let mut param_order: Vec<ParamName> = Vec::new();
-    let mut param_idx = 1;
-    let mut column_order: HashMap<ColumnName, usize> = HashMap::new();
+    let planner = QueryPlanner::new(ctx.schema);
+    let plan = planner.plan(query).map_err(|e| {
+        use crate::{QErrorKind, planner::PlanError};
+        let kind = match e {
+            PlanError::TableNotFound { table } => QErrorKind::TableNotFound { table },
+            PlanError::NoForeignKey { from, to } => QErrorKind::PlanMissing {
+                reason: format!("no FK relationship between {from} and {to}"),
+            },
+            PlanError::RelationNeedsFrom { relation } => QErrorKind::PlanMissing {
+                reason: format!("relation '{relation}' requires explicit 'from' clause"),
+            },
+        };
+        crate::QError {
+            source: ctx.source.clone(),
+            span: query
+                .from
+                .as_ref()
+                .map(|f| f.span)
+                .unwrap_or(dibs_query_schema::Span { offset: 0, len: 0 }),
+            kind,
+        }
+    })?;
 
     // Build column_order from plan's select_columns and count_subqueries
+    let mut column_order: HashMap<ColumnName, usize> = HashMap::new();
     let mut col_idx = 0;
     for col in &plan.select_columns {
         column_order.insert(col.result_alias.clone(), col_idx);
@@ -47,106 +62,160 @@ pub fn generate_select_sql(
         col_idx += 1;
     }
 
-    // SELECT with aliased columns
-    sql.push_str("SELECT ");
+    // Build SelectStmt using builder API
+    let mut stmt = SelectStmt::new();
 
-    // DISTINCT or DISTINCT ON
+    // DISTINCT / DISTINCT ON
     if let Some(distinct_on) = &query.distinct_on {
         if !distinct_on.0.is_empty() {
-            sql.push_str("DISTINCT ON (");
-            let distinct_cols: Vec<_> = distinct_on
+            let cols: Vec<Expr> = distinct_on
                 .0
                 .iter()
-                .map(|col| format!("\"t0\".\"{}\"", col.value))
+                .map(|col| Expr::qualified_column("t0".into(), col.value.clone()))
                 .collect();
-            sql.push_str(&distinct_cols.join(", "));
-            sql.push_str(") ");
+            stmt = stmt.distinct_on(cols);
         }
     } else if query.distinct.as_ref().map(|m| m.value).unwrap_or(false) {
-        sql.push_str("DISTINCT ");
+        stmt = stmt.distinct();
     }
 
-    sql.push_str(&plan.select_sql());
+    // SELECT columns (from plan)
+    for col in &plan.select_columns {
+        stmt = stmt.column(SelectColumn::aliased(
+            Expr::qualified_column(col.table_alias.as_str().into(), col.column.clone()),
+            col.result_alias.clone(),
+        ));
+    }
 
-    // FROM with JOINs (including relation filters in ON clauses)
-    sql.push_str(" FROM ");
-    sql.push_str(&plan.from_sql_with_params(&mut param_order, &mut param_idx));
+    // COUNT subqueries (rendered as raw SQL for now - complex subqueries)
+    for count in &plan.count_subqueries {
+        let subquery = format!(
+            "(SELECT COUNT(*) FROM \"{}\" WHERE \"{}\" = \"{}\".\"{}\")",
+            count.count_table, count.fk_column, count.parent_alias, count.parent_key
+        );
+        stmt = stmt.column(SelectColumn::aliased(
+            Expr::Raw(subquery),
+            count.result_alias.clone(),
+        ));
+    }
+
+    // FROM (from plan)
+    stmt = stmt.from(FromClause::aliased(
+        plan.from_table.clone(),
+        plan.from_alias.as_str().into(),
+    ));
+
+    // JOINs (from plan)
+    for join_clause in &plan.joins {
+        // Parse ON condition: stored as "alias.column" strings
+        let (left_alias, left_col) = parse_qualified_column(&join_clause.on_condition.0);
+        let (right_alias, right_col) = parse_qualified_column(&join_clause.on_condition.1);
+
+        let mut on_expr = Expr::qualified_column(left_alias.into(), left_col.into())
+            .eq(Expr::qualified_column(right_alias.into(), right_col.into()));
+
+        // Add extra conditions from relation-level WHERE
+        for cond in &join_clause.extra_conditions {
+            let value_expr = match &cond.value {
+                crate::planner::JoinConditionValue::Param(p) => Expr::param(p.clone()),
+                crate::planner::JoinConditionValue::Literal(lit) => Expr::string(lit),
+            };
+            on_expr = on_expr.and(
+                Expr::qualified_column(join_clause.alias.as_str().into(), cond.column.clone())
+                    .eq(value_expr),
+            );
+        }
+
+        let kind = match join_clause.join_type {
+            crate::planner::JoinType::Left => JoinKind::Left,
+            crate::planner::JoinType::Inner => JoinKind::Inner,
+        };
+
+        stmt = stmt.join(Join {
+            kind,
+            table: join_clause.table.clone(),
+            alias: Some(join_clause.alias.as_str().into()),
+            on: on_expr,
+        });
+    }
 
     // WHERE
     if let Some(where_clause) = &query.where_clause
-        && !where_clause.filters.is_empty()
+        && let Some(expr) = where_to_qualified_expr(where_clause, "t0")
     {
-        sql.push_str(" WHERE ");
-        let conditions: Vec<_> = where_clause
-            .filters
-            .iter()
-            .map(|(col_meta, filter_value)| {
-                // Prefix column with base table alias
-                let column = format!("t0.{}", col_meta.value);
-                let (cond, new_idx) =
-                    format_filter(&column, filter_value, param_idx, &mut param_order);
-                param_idx = new_idx;
-                cond
-            })
-            .collect();
-        sql.push_str(&conditions.join(" AND "));
+        stmt = stmt.where_(expr);
     }
 
     // ORDER BY
-    if let Some(order_by) = &query.order_by
-        && !order_by.columns.is_empty()
-    {
-        sql.push_str(" ORDER BY ");
-        let orders: Vec<_> = order_by
-            .columns
-            .iter()
-            .map(|(col_meta, dir_opt)| {
-                let dir = dir_opt.as_ref().map(|d| d.value.as_str()).unwrap_or("asc");
-                let dir_sql = if dir.eq_ignore_ascii_case("desc") {
-                    "DESC"
-                } else {
-                    "ASC"
-                };
-                format!("\"t0\".\"{}\" {}", col_meta.value, dir_sql)
-            })
-            .collect();
-        sql.push_str(&orders.join(", "));
+    if let Some(order_by) = &query.order_by {
+        for order in order_by_to_ast(order_by, "t0") {
+            stmt = stmt.order_by(order);
+        }
     }
 
     // LIMIT
     if let Some(limit) = &query.limit {
-        sql.push_str(" LIMIT ");
-        let limit_str = limit.value.as_str();
-        if let Some(param_name) = limit_str.strip_prefix('$') {
-            param_order.push(param_name.into());
-            sql.push_str(&format!("${}", param_idx));
-            param_idx += 1;
-        } else {
-            // Literal number
-            sql.push_str(limit_str);
-        }
+        stmt = stmt.limit(meta_string_to_expr(limit));
     }
 
     // OFFSET
     if let Some(offset) = &query.offset {
-        sql.push_str(" OFFSET ");
-        let offset_str = offset.value.as_str();
-        if let Some(param_name) = offset_str.strip_prefix('$') {
-            param_order.push(param_name.into());
-            sql.push_str(&format!("${}", param_idx));
-            param_idx += 1;
-        } else {
-            // Literal number
-            sql.push_str(offset_str);
-        }
+        stmt = stmt.offset(meta_string_to_expr(offset));
     }
 
-    let _ = param_idx;
+    // Render once
+    let rendered = render(&stmt);
 
     Ok(GeneratedSelect {
-        sql,
-        param_order,
+        sql: rendered.sql,
+        param_order: rendered.params,
         plan,
         column_order,
     })
+}
+
+/// Parse a qualified column string like "t0.id" into (alias, column).
+fn parse_qualified_column(s: &str) -> (&str, &str) {
+    let parts: Vec<&str> = s.split('.').collect();
+    if parts.len() == 2 {
+        (parts[0], parts[1])
+    } else {
+        ("", s)
+    }
+}
+
+/// Convert a WHERE clause to a dibs_sql::Expr with qualified columns.
+fn where_to_qualified_expr(where_clause: &Where, table_alias: &str) -> Option<Expr> {
+    let mut exprs: Vec<Expr> = vec![];
+
+    for (col_meta, filter_value) in &where_clause.filters {
+        let col_name: ColumnName = col_meta.value.clone();
+        // Create a qualified column name for the filter
+        let qualified_col: ColumnName = format!("{}.{}", table_alias, col_name).into();
+        if let Some(expr) = filter_value_to_expr(&qualified_col, filter_value) {
+            exprs.push(expr);
+        }
+    }
+
+    // AND all expressions together
+    let mut iter = exprs.into_iter();
+    let first = iter.next()?;
+    Some(iter.fold(first, |acc, expr| acc.and(expr)))
+}
+
+/// Convert ORDER BY clause to AST OrderBy items.
+fn order_by_to_ast(order_by: &QueryOrderBy, table_alias: &str) -> Vec<OrderBy> {
+    order_by
+        .columns
+        .iter()
+        .map(|(col_meta, dir_opt)| {
+            let expr = Expr::qualified_column(table_alias.into(), col_meta.value.clone());
+            let dir = dir_opt.as_ref().map(|d| d.value.as_str()).unwrap_or("asc");
+            if dir.eq_ignore_ascii_case("desc") {
+                OrderBy::desc(expr)
+            } else {
+                OrderBy::asc(expr)
+            }
+        })
+        .collect()
 }

--- a/crates/dibs-qgen/src/sqlgen/update.rs
+++ b/crates/dibs-qgen/src/sqlgen/update.rs
@@ -29,10 +29,10 @@ pub fn generate_update_sql(update: &Update) -> GeneratedUpdate {
     }
 
     // WHERE clause
-    if let Some(where_clause) = &update.where_clause {
-        if let Some(expr) = where_to_expr(where_clause) {
-            stmt = stmt.where_(expr);
-        }
+    if let Some(where_clause) = &update.where_clause
+        && let Some(expr) = where_to_expr(where_clause)
+    {
+        stmt = stmt.where_(expr);
     }
 
     // RETURNING clause

--- a/crates/dibs-qgen/src/sqlgen/update.rs
+++ b/crates/dibs-qgen/src/sqlgen/update.rs
@@ -61,7 +61,7 @@ mod tests {
     use crate::parse_query_file;
 
     fn get_first_update(source: &str) -> Update {
-        let file = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+        let (file, _source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
         for (_, decl) in file.0.iter() {
             if let dibs_query_schema::Decl::Update(u) = decl {
                 return u.clone();

--- a/crates/dibs-qgen/src/sqlgen/upsert.rs
+++ b/crates/dibs-qgen/src/sqlgen/upsert.rs
@@ -83,7 +83,7 @@ mod tests {
     use crate::parse_query_file;
 
     fn get_first_upsert(source: &str) -> Upsert {
-        let file = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+        let (file, _source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
         for (_, decl) in file.0.iter() {
             if let dibs_query_schema::Decl::Upsert(u) = decl {
                 return u.clone();

--- a/crates/dibs-qgen/src/sqlgen/upsert_many.rs
+++ b/crates/dibs-qgen/src/sqlgen/upsert_many.rs
@@ -296,7 +296,7 @@ mod tests {
     use crate::parse_query_file;
 
     fn get_first_upsert_many(source: &str) -> UpsertMany {
-        let file = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+        let (file, _source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
         for (_, decl) in file.0.iter() {
             if let dibs_query_schema::Decl::UpsertMany(um) = decl {
                 return um.clone();

--- a/crates/dibs-qgen/tests/postgres_integration.rs
+++ b/crates/dibs-qgen/tests/postgres_integration.rs
@@ -573,7 +573,7 @@ ProductWithVariants @select{
     assert_eq!(gizmo.1.len(), 0, "Gizmo should have 0 variants");
 
     // Also verify the generated Rust code looks correct
-    let code = generate_rust_code(&file, &schema, qsource);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
     tracing::info!("Generated code:\n{}", code.code);
 
     assert!(
@@ -1052,10 +1052,12 @@ UpdateProductStatus @update{
     returning {id, handle, status}
 }
 "#;
-    let (file, _qsource) = parse_test_query(source);
+    let (file, qsource) = parse_test_query(source);
     let update = first_update(&file);
 
-    let generated = dibs_qgen::generate_update_sql(update);
+    let schema = Schema::default();
+    let ctx = SqlGenContext::new(&schema, qsource);
+    let generated = dibs_qgen::generate_update_sql(&ctx, update).unwrap();
     tracing::info!("Generated UPDATE SQL: {}", generated.sql);
 
     // Verify SQL structure
@@ -1111,10 +1113,12 @@ DeleteProduct @delete{
     returning {id, handle}
 }
 "#;
-    let (file, _qsource) = parse_test_query(source);
+    let (file, qsource) = parse_test_query(source);
     let delete = first_delete(&file);
 
-    let generated = dibs_qgen::generate_delete_sql(delete);
+    let schema = Schema::default();
+    let ctx = SqlGenContext::new(&schema, qsource);
+    let generated = dibs_qgen::generate_delete_sql(&ctx, delete).unwrap();
     tracing::info!("Generated DELETE SQL: {}", generated.sql);
 
     // Verify SQL structure

--- a/crates/dibs-sql/Cargo.toml
+++ b/crates/dibs-sql/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2024"
 [package.metadata."docs.rs"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
+[package.metadata.cargo-shear]
+ignored = ["facet"]  # Used by strid's #[braid] macro
+
 [dependencies]
 blake3.workspace = true
 indexmap = "2"

--- a/crates/dibs/src/diff.rs
+++ b/crates/dibs/src/diff.rs
@@ -294,7 +294,7 @@ impl Change {
                 let quoted_cols: Vec<_> = idx
                     .columns
                     .iter()
-                    .map(|c| crate::schema::index_column_to_sql(c))
+                    .map(crate::schema::index_column_to_sql)
                     .collect();
                 let where_clause = idx
                     .where_clause

--- a/crates/dibs/src/introspect.rs
+++ b/crates/dibs/src/introspect.rs
@@ -272,6 +272,7 @@ async fn introspect_unique_constraints(client: &Client, table_name: &str) -> Res
 }
 
 /// Introspect foreign keys for a table.
+#[allow(clippy::type_complexity)]
 async fn introspect_foreign_keys(client: &Client, table_name: &str) -> Result<Vec<ForeignKey>> {
     let rows = client
         .query(

--- a/crates/dibs/src/lib.rs
+++ b/crates/dibs/src/lib.rs
@@ -346,9 +346,9 @@ pub fn build_queries(queries_path: impl AsRef<std::path::Path>) {
         .unwrap_or_else(|e| panic!("Failed to read {}: {}", queries_path.display(), e));
 
     let filename = camino::Utf8Path::new(queries_path.to_str().expect("path must be UTF-8"));
-    let file = parse_query_file(filename, &source).unwrap();
+    let (file, qsource) = parse_query_file(filename, &source).unwrap();
 
-    let generated = generate_rust_code(&file, &dibs_schema);
+    let generated = generate_rust_code(&file, &dibs_schema, qsource);
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let dest_path = std::path::Path::new(&out_dir).join("queries.rs");

--- a/crates/dibs/src/lib.rs
+++ b/crates/dibs/src/lib.rs
@@ -348,7 +348,8 @@ pub fn build_queries(queries_path: impl AsRef<std::path::Path>) {
     let filename = camino::Utf8Path::new(queries_path.to_str().expect("path must be UTF-8"));
     let (file, qsource) = parse_query_file(filename, &source).unwrap();
 
-    let generated = generate_rust_code(&file, &dibs_schema, qsource);
+    let generated =
+        generate_rust_code(&file, &dibs_schema, qsource).expect("query code generation failed");
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let dest_path = std::path::Path::new(&out_dir).join("queries.rs");

--- a/crates/dibs/src/query/exec.rs
+++ b/crates/dibs/src/query/exec.rs
@@ -39,6 +39,7 @@ impl<'a> Db<'a> {
     }
 
     /// Start building a SELECT query for a table.
+    #[allow(clippy::result_large_err)]
     pub fn select(&self, table: &str) -> Result<SelectBuilder<'_>, Error> {
         let table_def = self
             .table(table)
@@ -51,6 +52,7 @@ impl<'a> Db<'a> {
     }
 
     /// Start building an INSERT query for a table.
+    #[allow(clippy::result_large_err)]
     pub fn insert(&self, table: &str) -> Result<InsertBuilder<'_>, Error> {
         let table_def = self
             .table(table)
@@ -63,6 +65,7 @@ impl<'a> Db<'a> {
     }
 
     /// Start building an UPDATE query for a table.
+    #[allow(clippy::result_large_err)]
     pub fn update(&self, table: &str) -> Result<UpdateBuilder<'_>, Error> {
         let table_def = self
             .table(table)
@@ -75,6 +78,7 @@ impl<'a> Db<'a> {
     }
 
     /// Start building a DELETE query for a table.
+    #[allow(clippy::result_large_err)]
     pub fn delete(&self, table: &str) -> Result<DeleteBuilder<'_>, Error> {
         let table_def = self
             .table(table)

--- a/crates/dibs/src/query/expr.rs
+++ b/crates/dibs/src/query/expr.rs
@@ -117,6 +117,7 @@ impl Expr {
     }
 
     /// Negate an expression
+    #[allow(clippy::should_implement_trait)]
     pub fn not(expr: Expr) -> Self {
         Expr::Not(Box::new(expr))
     }

--- a/crates/dibs/src/query/row.rs
+++ b/crates/dibs/src/query/row.rs
@@ -56,6 +56,7 @@ pub struct RowContext<'a> {
 }
 
 /// Convert a tokio_postgres Row to our Row type.
+#[allow(clippy::result_large_err)]
 pub fn pg_row_to_row(
     pg_row: &tokio_postgres::Row,
     columns: &[(String, PgType)],
@@ -72,6 +73,7 @@ pub fn pg_row_to_row(
 }
 
 /// Extract a value from a Postgres row at a given index.
+#[allow(clippy::result_large_err)]
 fn pg_value_to_value(
     row: &tokio_postgres::Row,
     idx: usize,

--- a/crates/dibs/src/schema.rs
+++ b/crates/dibs/src/schema.rs
@@ -116,7 +116,7 @@ pub fn create_table_sql(table: &Table) -> String {
 /// Generate CREATE INDEX SQL statement for a given index.
 pub fn create_index_sql(table: &Table, idx: &Index) -> String {
     let unique = if idx.unique { "UNIQUE " } else { "" };
-    let quoted_cols: Vec<_> = idx.columns.iter().map(|c| index_column_to_sql(c)).collect();
+    let quoted_cols: Vec<_> = idx.columns.iter().map(index_column_to_sql).collect();
     let where_clause = idx
         .where_clause
         .as_ref()

--- a/crates/dibs/src/schema/codegen.rs
+++ b/crates/dibs/src/schema/codegen.rs
@@ -1,4 +1,4 @@
-use super::{Schema, Table};
+use super::Schema;
 use crate::schema::{
     create_index_sql, create_table_sql, create_trigger_check_function_sql, create_trigger_check_sql,
 };

--- a/examples/my-app-workspace/my-app-queries/.dibs-queries/queries.styx
+++ b/examples/my-app-workspace/my-app-queries/.dibs-queries/queries.styx
@@ -127,11 +127,12 @@ CountProducts @select{
 //     fields {id, handle, price}
 // }
 
-// Query with literal @in filter
+// Query with @in filter using a literal array expression
+// The array is formatted as a SQL literal that PostgreSQL can parse
 
 ProductsByKnownHandles @select{
     from product
-    where {handle @in("prod-1" "prod-2" "prod-3"), deleted_at @null}
+    where {handle @in("'prod-1','prod-2','prod-3'"), deleted_at @null}
     fields {id, handle, status}
 }
 
@@ -341,7 +342,7 @@ ProductDetailsFull @select{
         updated_at
         locales @rel{
             from product_translation
-            where {locale @in("en" "fr")}
+            where {locale @in("'en','fr'")}
             order-by {locale asc}
             fields {locale, title, description}
         }


### PR DESCRIPTION
## Summary

This PR fixes #13 by wiring up the `FunctionSpec` and `ArgSpec` validation system that was designed but unused.

- Added `validate_query_file()` that validates all filter arguments during query parsing
- `FunctionSpec::parse_args()` is now called for each filter to validate argument counts and types
- Rich error messages with source spans are produced when validation fails
- Fixed pre-existing clippy warnings across the codebase
- Removed unused dependencies detected by cargo-shear

The validation now happens at parse time rather than SQL generation time, providing earlier feedback for invalid queries.

## Test plan

- [x] Library tests pass (`cargo nextest run -p dibs-qgen --lib`)
- [x] Clippy passes with `-D warnings`
- [x] Cargo-shear passes
- [ ] CI integration tests (require Docker)