### PR TITLE
Note that tables need to use `#[facet(derive(dibs::Table))]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tables are defined as Rust structs with facet attributes:
 
 ```rust
 #[derive(Facet)]
+#[facet(derive(dibs::Table))]
 #[facet(dibs::table = "user")]
 pub struct User {
     #[facet(dibs::pk)]

--- a/README.md.in
+++ b/README.md.in
@@ -10,6 +10,7 @@ Tables are defined as Rust structs with facet attributes:
 
 ```rust
 #[derive(Facet)]
+#[facet(derive(dibs::Table))]
 #[facet(dibs::table = "user")]
 pub struct User {
     #[facet(dibs::pk)]

--- a/docs/META-TABLES.md
+++ b/docs/META-TABLES.md
@@ -136,6 +136,7 @@ The proc macro captures source location via `Span`:
 
 ```rust
 #[derive(Facet)]
+#[facet(derive(dibs::Table))]
 #[facet(dibs::table = "users")]
 /// User accounts in the system
 struct User {

--- a/docs/MIGRATIONS-VISION.md
+++ b/docs/MIGRATIONS-VISION.md
@@ -21,6 +21,7 @@ my-app/
 use facet::Facet;
 
 #[derive(Facet)]
+#[facet(derive(dibs::Table))]
 #[facet(dibs::table = "users")]
 pub struct User {
     #[facet(dibs::pk)]

--- a/docs/content/guide/admin-ui.md
+++ b/docs/content/guide/admin-ui.md
@@ -24,6 +24,7 @@ Remember those admin UI attributes from the schema guide? Here's where they shin
 
 ```rust
 #[derive(Facet)]
+#[facet(derive(dibs::Table))]
 #[facet(dibs::table = "products")]
 #[facet(dibs::icon = "package")]  // Shows a package icon in the UI
 pub struct Product {

--- a/docs/content/guide/first-table.md
+++ b/docs/content/guide/first-table.md
@@ -14,6 +14,7 @@ Add this to `crates/my-app-db/src/lib.rs`:
 use facet::Facet;
 
 #[derive(Facet)]
+#[facet(derive(dibs::Table))]
 #[facet(dibs::table = "users")]
 pub struct User {
     #[facet(dibs::pk)] // primary key

--- a/docs/content/internals/meta-tables.md
+++ b/docs/content/internals/meta-tables.md
@@ -140,6 +140,7 @@ The proc macro captures source location via `Span`:
 
 ```rust
 #[derive(Facet)]
+#[facet(derive(dibs::Table))]
 #[facet(dibs::table = "users")]
 /// User accounts in the system
 struct User {


### PR DESCRIPTION
This was missing from documentation, making it outdated and hard to follow.