### PR TITLE
Point Dibs users to the Facet monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # dibs
 
+## Moved to facet-rs/facet
+
+Dibs now lives in the [Facet monorepo](https://github.com/facet-rs/facet/tree/main/dibs).
+
+This repository is archived. Please use [facet-rs/facet](https://github.com/facet-rs/facet) for issues, pull requests, and future development.
+
 A Postgres toolkit for Rust, powered by [facet](https://github.com/facet-rs/facet) reflection.
 
 ## Components

--- a/README.md.in
+++ b/README.md.in
@@ -1,5 +1,11 @@
 # dibs
 
+## Moved to facet-rs/facet
+
+Dibs now lives in the [Facet monorepo](https://github.com/facet-rs/facet/tree/main/dibs).
+
+This repository is archived. Please use [facet-rs/facet](https://github.com/facet-rs/facet) for issues, pull requests, and future development.
+
 A Postgres toolkit for Rust, powered by [facet](https://github.com/facet-rs/facet) reflection.
 
 ## Components


### PR DESCRIPTION
Dibs has moved into the Facet monorepo. This adds a prominent README notice pointing users to the new home for development, issues, and PRs.