### PR TITLE
Add int32 params and arithmetic update expressions

### DIFF
--- a/crates/dibs-cli/src/lints/type_mismatch.rs
+++ b/crates/dibs-cli/src/lints/type_mismatch.rs
@@ -48,6 +48,7 @@ fn param_type_name(param_type: &ParamType) -> String {
     match param_type {
         ParamType::String => "string".to_string(),
         ParamType::Int => "int".to_string(),
+        ParamType::Int32 => "int32".to_string(),
         ParamType::Float => "float".to_string(),
         ParamType::Bool => "bool".to_string(),
         ParamType::Uuid => "uuid".to_string(),

--- a/crates/dibs-qgen/src/error.rs
+++ b/crates/dibs-qgen/src/error.rs
@@ -101,6 +101,16 @@ pub enum QErrorKind {
         /// Description of the type mismatch
         reason: String,
     },
+
+    /// Invalid arguments for an update expression.
+    InvalidUpdateArgCount {
+        /// Update expression name.
+        expression: String,
+        /// Expected number of arguments.
+        expected: usize,
+        /// Actual number of arguments.
+        actual: usize,
+    },
 }
 
 impl fmt::Display for QErrorKind {
@@ -164,6 +174,15 @@ impl fmt::Display for QErrorKind {
             QErrorKind::InvalidFilterArgType { filter, reason } => {
                 write!(f, "invalid argument for filter '{}': {}", filter, reason)
             }
+            QErrorKind::InvalidUpdateArgCount {
+                expression,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "invalid arguments for update expression '{}': expected {} arguments, got {}",
+                expression, expected, actual
+            ),
         }
     }
 }

--- a/crates/dibs-qgen/src/rustgen/mod.rs
+++ b/crates/dibs-qgen/src/rustgen/mod.rs
@@ -1014,6 +1014,7 @@ fn param_type_to_rust(ty: &dibs_query_schema::ParamType) -> String {
     match ty {
         ParamType::String => "String".to_string(),
         ParamType::Int => "i64".to_string(),
+        ParamType::Int32 => "i32".to_string(),
         ParamType::Float => "f64".to_string(),
         ParamType::Bool => "bool".to_string(),
         ParamType::Uuid => "Uuid".to_string(),
@@ -1176,7 +1177,7 @@ fn generate_upsert_code(
 ) -> Result<(), QError> {
     let name = &name_meta.value;
     let fn_name = to_snake_case(name);
-    let generated = crate::sqlgen::generate_upsert_sql(upsert);
+    let generated = crate::sqlgen::generate_upsert_sql(&_ctx.sqlgen_ctx(), upsert)?;
 
     let has_returning = upsert.returning.is_some();
     let return_ty = if !has_returning {

--- a/crates/dibs-qgen/src/rustgen/tests.rs
+++ b/crates/dibs-qgen/src/rustgen/tests.rs
@@ -254,6 +254,22 @@ CreatePasskey @insert{
 }
 
 #[test]
+fn test_generate_int32_param_takes_i32() {
+    let source = r#"
+CreateAttachment @insert{
+  params { message_id @string, position @int32 }
+  into message_attachments
+  values { message_id $message_id, position $position }
+}
+"#;
+    let (file, qsource) = parse_test(source);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
+
+    assert!(code.code.contains("position: &i32"));
+    assert!(!code.code.contains("position: &i64"));
+}
+
+#[test]
 fn test_snake_case() {
     assert_eq!(to_snake_case("ProductListing"), "product_listing");
     assert_eq!(to_snake_case("AllProducts"), "all_products");
@@ -726,6 +742,37 @@ UpdateUserEmail @update{
     assert!(code.code.contains("UPDATE"));
     assert!(code.code.contains("SET"));
     assert!(code.code.contains("WHERE"));
+}
+
+#[test]
+fn test_generate_arithmetic_update_returning_result() {
+    let source = r#"
+IncrementRefcount @update{
+  params { object_key @string }
+  table objects
+  set { refcount @add(1) }
+  where { object_key $object_key }
+  returning { refcount }
+}
+"#;
+    let (file, qsource) = parse_test(source);
+    let schema = make_test_schema(vec![make_test_table(
+        "objects",
+        &[
+            ("object_key", PgType::Text, false),
+            ("refcount", PgType::BigInt, false),
+        ],
+        vec![],
+    )]);
+    let code = generate_rust_code(&file, &schema, qsource).unwrap();
+
+    assert!(code.code.contains("pub struct IncrementRefcountResult"));
+    assert!(code.code.contains("pub refcount: i64"));
+    assert!(code.code.contains(r#"SET "refcount" = "refcount" + 1"#));
+    assert!(
+        code.code
+            .contains("Result<Option<IncrementRefcountResult>, QueryError>")
+    );
 }
 
 #[test]

--- a/crates/dibs-qgen/src/sqlgen/common.rs
+++ b/crates/dibs-qgen/src/sqlgen/common.rs
@@ -5,7 +5,7 @@ use crate::filter_spec::{
     CONTAINS_SPEC, EQ_SPEC, GT_SPEC, GTE_SPEC, ILIKE_SPEC, IN_SPEC, JSON_GET_SPEC,
     JSON_GET_TEXT_SPEC, KEY_EXISTS_SPEC, LIKE_SPEC, LT_SPEC, LTE_SPEC, NE_SPEC,
 };
-use crate::{FilterArg, QError};
+use crate::{FilterArg, QError, QErrorKind};
 use dibs_query_schema::{
     FilterValue, Meta, ParamType, Params, Payload, Span, UpdateValue, ValueExpr, Where,
 };
@@ -316,53 +316,113 @@ pub fn cast_for_jsonb_param(expr: Expr, params: Option<&Params>) -> Expr {
     }
 }
 
+/// Convert a value in an UPDATE SET clause, where arithmetic tags are valid.
+pub fn update_set_value_to_expr(
+    ctx: &SqlGenContext<'_>,
+    span: Span,
+    column: &ColumnName,
+    expr: &Option<ValueExpr>,
+    params: Option<&Params>,
+) -> Result<Expr, QError> {
+    if let Some(ValueExpr::Other {
+        tag: Some(name),
+        content: Some(payload),
+    }) = expr
+        && (name.eq_ignore_ascii_case("add") || name.eq_ignore_ascii_case("sub"))
+    {
+        let operand = match payload {
+            Payload::Scalar(arg) => meta_string_to_expr(arg),
+            Payload::Seq(args) if args.len() == 1 => {
+                value_expr_to_expr(column, &Some(args[0].clone()), params)
+            }
+            Payload::Seq(args) => {
+                return Err(QError {
+                    source: ctx.source.clone(),
+                    span,
+                    kind: QErrorKind::InvalidUpdateArgCount {
+                        expression: name.clone(),
+                        expected: 1,
+                        actual: args.len(),
+                    },
+                });
+            }
+        };
+        return Ok(Expr::BinOp {
+            left: Box::new(Expr::column(column.clone())),
+            op: if name.eq_ignore_ascii_case("add") {
+                BinOp::Add
+            } else {
+                BinOp::Sub
+            },
+            right: Box::new(operand),
+        });
+    }
+    Ok(value_expr_to_expr(column, expr, params))
+}
+
 /// Convert an UpdateValue to a dibs_sql::Expr.
 ///
 /// Similar to value_expr_to_expr but for the update clause in upserts.
 pub fn update_value_to_expr(
+    ctx: &SqlGenContext<'_>,
+    span: Span,
     column: &ColumnName,
     expr: &Option<UpdateValue>,
     params: Option<&Params>,
-) -> Expr {
+) -> Result<Expr, QError> {
     let raw = match expr {
-        None => {
-            // Shorthand: {col} means use EXCLUDED.col
-            Expr::excluded(column.clone())
-        }
+        None => Expr::excluded(column.clone()),
         Some(UpdateValue::Default) => Expr::Default,
         Some(UpdateValue::Other { tag, content }) => match (tag, content) {
-            // Bare scalar (param reference like $name or literal)
             (None, Some(Payload::Scalar(s))) => meta_string_to_expr(s),
-            // `@null` is the SQL keyword NULL, not a nullary function `NULL()`.
             (Some(name), None) if name.eq_ignore_ascii_case("null") => Expr::Null,
-            // Nullary function like @now
             (Some(name), None) => Expr::FnCall {
                 name: name.to_uppercase(),
                 args: vec![],
             },
-            // Function with args
-            (Some(name), Some(Payload::Seq(args))) => {
-                // Convert each arg - but we need ValueExpr not UpdateValue
-                // For now, handle the common cases
-                let sql_args: Vec<Expr> = args
-                    .iter()
-                    .map(|a| value_expr_to_expr(column, &Some(a.clone()), params))
-                    .collect();
-                Expr::FnCall {
-                    name: name.to_uppercase(),
-                    args: sql_args,
+            (Some(name), Some(payload))
+                if name.eq_ignore_ascii_case("add") || name.eq_ignore_ascii_case("sub") =>
+            {
+                let operand = match payload {
+                    Payload::Scalar(arg) => meta_string_to_expr(arg),
+                    Payload::Seq(args) if args.len() == 1 => {
+                        value_expr_to_expr(column, &Some(args[0].clone()), params)
+                    }
+                    Payload::Seq(args) => {
+                        return Err(QError {
+                            source: ctx.source.clone(),
+                            span,
+                            kind: QErrorKind::InvalidUpdateArgCount {
+                                expression: name.clone(),
+                                expected: 1,
+                                actual: args.len(),
+                            },
+                        });
+                    }
+                };
+                Expr::BinOp {
+                    left: Box::new(Expr::column(column.clone())),
+                    op: if name.eq_ignore_ascii_case("add") {
+                        BinOp::Add
+                    } else {
+                        BinOp::Sub
+                    },
+                    right: Box::new(operand),
                 }
             }
-            // Function with single scalar arg
-            (Some(name), Some(Payload::Scalar(s))) => Expr::FnCall {
+            (Some(name), Some(Payload::Seq(args))) => Expr::FnCall {
                 name: name.to_uppercase(),
-                args: vec![meta_string_to_expr(s)],
+                args: args
+                    .iter()
+                    .map(|arg| value_expr_to_expr(column, &Some(arg.clone()), params))
+                    .collect(),
             },
-            // Shouldn't happen but handle gracefully
-            (None, None) => Expr::Null,
-            // Sequence without tag - shouldn't happen
-            (None, Some(Payload::Seq(_))) => Expr::Null,
+            (Some(name), Some(Payload::Scalar(arg))) => Expr::FnCall {
+                name: name.to_uppercase(),
+                args: vec![meta_string_to_expr(arg)],
+            },
+            (None, None) | (None, Some(Payload::Seq(_))) => Expr::Null,
         },
     };
-    cast_for_jsonb_param(raw, params)
+    Ok(cast_for_jsonb_param(raw, params))
 }

--- a/crates/dibs-qgen/src/sqlgen/insert_many.rs
+++ b/crates/dibs-qgen/src/sqlgen/insert_many.rs
@@ -186,6 +186,7 @@ fn param_type_to_pg_array(ty: &ParamType) -> &'static str {
     match ty {
         ParamType::String => "text[]",
         ParamType::Int => "bigint[]",
+        ParamType::Int32 => "integer[]",
         ParamType::Float => "double precision[]",
         ParamType::Bool => "boolean[]",
         ParamType::Uuid => "uuid[]",

--- a/crates/dibs-qgen/src/sqlgen/update.rs
+++ b/crates/dibs-qgen/src/sqlgen/update.rs
@@ -1,7 +1,7 @@
 //! SQL generation for UPDATE statements.
 
 use super::SqlGenContext;
-use super::common::{value_expr_to_expr, where_to_expr_validated};
+use super::common::{update_set_value_to_expr, where_to_expr_validated};
 use crate::QError;
 use dibs_query_schema::Update;
 use dibs_sql::{ColumnName, ParamName, UpdateStmt, render};
@@ -29,7 +29,13 @@ pub fn generate_update_sql(
     // SET clause
     for (col_meta, value_expr) in &update.set.columns {
         let col_name = &col_meta.value;
-        let expr = value_expr_to_expr(col_name, value_expr, update.params.as_ref());
+        let expr = update_set_value_to_expr(
+            ctx,
+            col_meta.span,
+            col_name,
+            value_expr,
+            update.params.as_ref(),
+        )?;
         stmt = stmt.set(col_name.clone(), expr);
     }
 
@@ -138,6 +144,82 @@ ClearDeletedAt @update{
             "must not emit the invalid `NULL()`: {}",
             result.sql
         );
+    }
+
+    #[test]
+    fn test_update_arithmetic_expression() {
+        let source = r#"
+IncrementRefcount @update{
+    table objects
+    set {refcount @add(1)}
+    where {object_key $object_key}
+    params {object_key @string}
+    returning {refcount}
+}
+"#;
+        let (update, qsource) = get_first_update(source);
+        let schema = Schema::default();
+        let ctx = SqlGenContext::new(&schema, std::sync::Arc::new(qsource));
+        let result = generate_update_sql(&ctx, &update).unwrap();
+        assert!(
+            result.sql.contains(r#"SET "refcount" = "refcount" + 1"#),
+            "unexpected SQL: {}",
+            result.sql
+        );
+        assert!(!result.sql.contains("ADD("));
+    }
+
+    #[test]
+    fn test_update_arithmetic_rejects_wrong_arity() {
+        for source in [
+            r#"
+BadIncrement @update{
+    table objects
+    set {refcount @add()}
+}
+"#,
+            r#"
+BadIncrement @update{
+    table objects
+    set {refcount @add(1 2)}
+}
+"#,
+        ] {
+            let (update, qsource) = get_first_update(source);
+            let schema = Schema::default();
+            let ctx = SqlGenContext::new(&schema, std::sync::Arc::new(qsource));
+            let err = generate_update_sql(&ctx, &update).unwrap_err();
+            assert!(matches!(
+                err.kind,
+                crate::QErrorKind::InvalidUpdateArgCount {
+                    expected: 1,
+                    actual: 0 | 2,
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn test_insert_add_remains_a_function_call() {
+        let source = r#"
+InsertCounter @insert{
+    into objects
+    values {refcount @add(1)}
+}
+"#;
+        let (file, _) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+        let insert = file
+            .0
+            .values()
+            .find_map(|decl| match decl {
+                dibs_query_schema::Decl::Insert(insert) => Some(insert),
+                _ => None,
+            })
+            .unwrap();
+        let result = crate::sqlgen::generate_insert_sql(insert);
+        assert!(result.sql.contains(r#"VALUES (ADD(1))"#));
+        assert!(!result.sql.contains(r#"\"refcount\" + 1"#));
     }
 
     #[test]

--- a/crates/dibs-qgen/src/sqlgen/upsert.rs
+++ b/crates/dibs-qgen/src/sqlgen/upsert.rs
@@ -1,6 +1,8 @@
 //! SQL generation for UPSERT statements (INSERT ... ON CONFLICT ... DO UPDATE).
 
+use super::SqlGenContext;
 use super::common::{update_value_to_expr, value_expr_to_expr};
+use crate::QError;
 use dibs_query_schema::Upsert;
 use dibs_sql::{
     ColumnName, ConflictAction, InsertStmt, OnConflict, ParamName, UpdateAssignment, render,
@@ -20,7 +22,10 @@ pub struct GeneratedUpsert {
 }
 
 /// Generate SQL for an UPSERT statement.
-pub fn generate_upsert_sql(upsert: &Upsert) -> GeneratedUpsert {
+pub fn generate_upsert_sql(
+    ctx: &SqlGenContext<'_>,
+    upsert: &Upsert,
+) -> Result<GeneratedUpsert, QError> {
     let mut stmt = InsertStmt::new(upsert.into.value.clone());
 
     // VALUES clause
@@ -47,10 +52,16 @@ pub fn generate_upsert_sql(upsert: &Upsert) -> GeneratedUpsert {
         .iter()
         .map(|(col_meta, update_value)| {
             let col_name = &col_meta.value;
-            let expr = update_value_to_expr(col_name, update_value, upsert.params.as_ref());
-            UpdateAssignment::new(col_name.clone(), expr)
+            let expr = update_value_to_expr(
+                ctx,
+                col_meta.span,
+                col_name,
+                update_value,
+                upsert.params.as_ref(),
+            )?;
+            Ok(UpdateAssignment::new(col_name.clone(), expr))
         })
-        .collect();
+        .collect::<Result<_, QError>>()?;
 
     stmt = stmt.on_conflict(OnConflict {
         columns: conflict_columns,
@@ -70,11 +81,11 @@ pub fn generate_upsert_sql(upsert: &Upsert) -> GeneratedUpsert {
 
     let rendered = render(&stmt);
 
-    GeneratedUpsert {
+    Ok(GeneratedUpsert {
         sql: rendered.sql,
         params: rendered.params,
         returning_columns,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -82,11 +93,11 @@ mod tests {
     use super::*;
     use crate::parse_query_file;
 
-    fn get_first_upsert(source: &str) -> Upsert {
-        let (file, _source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
+    fn get_first_upsert(source: &str) -> (Upsert, crate::QSource) {
+        let (file, source) = parse_query_file(camino::Utf8Path::new("<test>"), source).unwrap();
         for (_, decl) in file.0.iter() {
             if let dibs_query_schema::Decl::Upsert(u) = decl {
-                return u.clone();
+                return (u.clone(), (*source).clone());
             }
         }
         panic!("No upsert found in source");
@@ -106,8 +117,10 @@ UpsertProduct @upsert{
     returning {id, name, price}
 }
 "#;
-        let upsert = get_first_upsert(source);
-        let result = generate_upsert_sql(&upsert);
+        let (upsert, source) = get_first_upsert(source);
+        let schema = dibs_db_schema::Schema::default();
+        let ctx = SqlGenContext::new(&schema, std::sync::Arc::new(source));
+        let result = generate_upsert_sql(&ctx, &upsert).unwrap();
         insta::assert_snapshot!(result.sql);
     }
 
@@ -125,8 +138,10 @@ UpsertProduct @upsert{
     returning {id, handle, name, updated_at}
 }
 "#;
-        let upsert = get_first_upsert(source);
-        let result = generate_upsert_sql(&upsert);
+        let (upsert, source) = get_first_upsert(source);
+        let schema = dibs_db_schema::Schema::default();
+        let ctx = SqlGenContext::new(&schema, std::sync::Arc::new(source));
+        let result = generate_upsert_sql(&ctx, &upsert).unwrap();
         insta::assert_snapshot!(result.sql);
     }
 
@@ -144,8 +159,10 @@ UpsertTranslation @upsert{
     returning {id}
 }
 "#;
-        let upsert = get_first_upsert(source);
-        let result = generate_upsert_sql(&upsert);
+        let (upsert, source) = get_first_upsert(source);
+        let schema = dibs_db_schema::Schema::default();
+        let ctx = SqlGenContext::new(&schema, std::sync::Arc::new(source));
+        let result = generate_upsert_sql(&ctx, &upsert).unwrap();
         insta::assert_snapshot!(result.sql);
     }
 }

--- a/crates/dibs-qgen/src/sqlgen/upsert_many.rs
+++ b/crates/dibs-qgen/src/sqlgen/upsert_many.rs
@@ -279,6 +279,7 @@ fn param_type_to_pg_array(ty: &ParamType) -> &'static str {
     match ty {
         ParamType::String => "text[]",
         ParamType::Int => "bigint[]",
+        ParamType::Int32 => "integer[]",
         ParamType::Float => "double precision[]",
         ParamType::Bool => "boolean[]",
         ParamType::Uuid => "uuid[]",

--- a/crates/dibs-qgen/tests/postgres_integration.rs
+++ b/crates/dibs-qgen/tests/postgres_integration.rs
@@ -1177,10 +1177,12 @@ UpsertProduct @upsert{
     returning {id, handle, status}
 }
 "#;
-    let (file, _qsource) = parse_test_query(source);
+    let (file, qsource) = parse_test_query(source);
     let upsert = first_upsert(&file);
+    let schema = Schema::default();
+    let ctx = dibs_qgen::SqlGenContext::new(&schema, qsource);
 
-    let generated = dibs_qgen::generate_upsert_sql(upsert);
+    let generated = dibs_qgen::generate_upsert_sql(&ctx, upsert).unwrap();
     tracing::info!("Generated UPSERT SQL: {}", generated.sql);
 
     // Verify SQL structure
@@ -1237,10 +1239,12 @@ UpsertProduct @upsert{
     returning {id, handle, status}
 }
 "#;
-    let (file, _qsource) = parse_test_query(source);
+    let (file, qsource) = parse_test_query(source);
     let upsert = first_upsert(&file);
+    let schema = Schema::default();
+    let ctx = dibs_qgen::SqlGenContext::new(&schema, qsource);
 
-    let generated = dibs_qgen::generate_upsert_sql(upsert);
+    let generated = dibs_qgen::generate_upsert_sql(&ctx, upsert).unwrap();
 
     // Upsert existing product - should update
     let handle = "widget".to_string(); // exists from test data

--- a/crates/dibs-query-schema/src/lib.rs
+++ b/crates/dibs-query-schema/src/lib.rs
@@ -402,6 +402,8 @@ pub struct Params {
 pub enum ParamType {
     String,
     Int,
+    /// `i32` / PostgreSQL `INTEGER`.
+    Int32,
     /// `f64` / `DOUBLE PRECISION`.
     Float,
     Bool,

--- a/crates/dibs-sql/src/expr.rs
+++ b/crates/dibs-sql/src/expr.rs
@@ -105,6 +105,10 @@ pub enum BinOp {
     Gt,
     /// Greater than or equal: `>=`
     Ge,
+    /// Addition: `+`
+    Add,
+    /// Subtraction: `-`
+    Sub,
     /// Logical AND
     And,
     /// Logical OR
@@ -120,6 +124,8 @@ impl BinOp {
             BinOp::Le => "<=",
             BinOp::Gt => ">",
             BinOp::Ge => ">=",
+            BinOp::Add => "+",
+            BinOp::Sub => "-",
             BinOp::And => "AND",
             BinOp::Or => "OR",
         }


### PR DESCRIPTION
## Summary
- add `@int32` parameters mapped to Rust `i32` and PostgreSQL `INTEGER`/`integer[]`
- add update-only `@add`/`@sub` expressions for UPDATE and UPSERT assignments
- reject arithmetic expressions with zero or multiple operands instead of silently miscompiling them
- keep `@add` in INSERT values as an ordinary SQL function call

## Verification
- `cargo nextest run -p dibs-query-schema -p dibs-qgen --lib` (57 passed)
- `cargo check -p dibs-qgen -p dibs-query-schema -p dibs-cli --all-targets --message-format=short`
- Walkway generated `i32` attachment signatures and `SET refcount = refcount + 1`; its broker suite and live PostgreSQL peer integrations passed against the branch commit.
