### PR TITLE
Use canonical Strid repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4290,7 +4290,7 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 [[package]]
 name = "strid"
 version = "11.0.0-rc.5"
-source = "git+https://github.com/bearcove/strid-next?rev=98a76b12c2a65f1a909123ec5a03fcc12d89444b#98a76b12c2a65f1a909123ec5a03fcc12d89444b"
+source = "git+https://github.com/bearcove/strid?rev=c48464a22b6511b0119be92ea2c86c1f61e06153#c48464a22b6511b0119be92ea2c86c1f61e06153"
 dependencies = [
  "facet 0.50.0-rc.5 (git+https://github.com/facet-rs/facet?rev=5705fa6c51289bea49f5729c52dc5e23cedce4f8)",
  "strid-macros",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "strid-macros"
 version = "11.0.0-rc.4"
-source = "git+https://github.com/bearcove/strid-next?rev=98a76b12c2a65f1a909123ec5a03fcc12d89444b#98a76b12c2a65f1a909123ec5a03fcc12d89444b"
+source = "git+https://github.com/bearcove/strid?rev=c48464a22b6511b0119be92ea2c86c1f61e06153#c48464a22b6511b0119be92ea2c86c1f61e06153"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ facet-reflect = { git = "https://github.com/facet-rs/facet", rev = "5705fa6c5128
 facet-testhelpers = { git = "https://github.com/facet-rs/facet", rev = "5705fa6c51289bea49f5729c52dc5e23cedce4f8" }
 facet-tokio-postgres = { path = "crates/facet-tokio-postgres", version = "0.50.0-rc.5" }
 figue = { git = "https://github.com/bearcove/figue", rev = "361672c57316b2202ac0372f1c64988d8acfc6b6" }
-strid = { git = "https://github.com/bearcove/strid-next", rev = "98a76b12c2a65f1a909123ec5a03fcc12d89444b" }
+strid = { git = "https://github.com/bearcove/strid", rev = "c48464a22b6511b0119be92ea2c86c1f61e06153" }
 snark = { git = "https://github.com/bearcove/snark", rev = "3f4a3481608c67cc1148ae0d3cd1cf230fcb6280" }
 snark-dsl = { git = "https://github.com/bearcove/snark", rev = "3f4a3481608c67cc1148ae0d3cd1cf230fcb6280" }
 margin = { git = "https://github.com/bearcove/snark", rev = "3f4a3481608c67cc1148ae0d3cd1cf230fcb6280" }


### PR DESCRIPTION
## Summary

Repoint Dibs from the temporary private `bearcove/strid-next` bridge to the canonical, now-unarchived `bearcove/strid` repository. The branch is rebased on current `main` and pins the merged Strid commit.

## Changes

- replace the Strid Git source and revision in `Cargo.toml`
- update `Cargo.lock` so both `strid` and `strid-macros` resolve from `bearcove/strid@c48464a2`

## Verification

- `cargo check --locked -p dibs-sql`
- confirmed no `strid-next` source remains in `Cargo.toml` or `Cargo.lock`
- full Dibs tests are known-broken and are not a gate for this dependency-only cutover
