### PR TITLE
release: bootstrap canonical rc.6 packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "dibs"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "blake3",
  "bytes",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "dibs-cli"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "arborium",
  "arborium-highlight",
@@ -1012,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "dibs-config"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "dibs-db-schema"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "chrono",
  "dibs-jsonb",
@@ -1035,14 +1035,14 @@ dependencies = [
 
 [[package]]
 name = "dibs-jsonb"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "dibs-macros"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "dibs-proto"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "facet",
  "vox",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "dibs-qgen"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "ariadne",
  "camino",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "dibs-query-schema"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "dibs-sql",
  "facet",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "dibs-runtime"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "dibs-jsonb",
  "facet",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "dibs-sql"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "blake3",
  "facet",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "facet-tokio-postgres"
-version = "0.50.0-rc.5"
+version = "0.50.0-rc.6"
 dependencies = [
  "chrono",
  "dibs-jsonb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,15 @@ resolver = "3"
 rust-version = "1.92"
 
 [workspace.dependencies]
-dibs = { path = "crates/dibs", version = "0.2.0-rc.5" }
-dibs-config = { path = "crates/dibs-config", version = "0.2.0-rc.5" }
-dibs-macros = { path = "crates/dibs-macros", version = "0.2.0-rc.4" }
-dibs-proto = { path = "crates/dibs-proto", version = "0.2.0-rc.5" }
-dibs-qgen = { path = "crates/dibs-qgen", version = "0.2.0-rc.5" }
-dibs-query-schema = { path = "crates/dibs-query-schema", version = "0.2.0-rc.5" }
-dibs-db-schema = { path = "crates/dibs-db-schema", version = "0.2.0-rc.5" }
-dibs-jsonb = { path = "crates/dibs-jsonb", version = "0.2.0-rc.5" }
-dibs-runtime = { path = "crates/dibs-runtime", version = "0.2.0-rc.5" }
+dibs = { path = "crates/dibs", version = "0.2.0-rc.6" }
+dibs-config = { path = "crates/dibs-config", version = "0.2.0-rc.6" }
+dibs-macros = { path = "crates/dibs-macros", version = "0.2.0-rc.6" }
+dibs-proto = { path = "crates/dibs-proto", version = "0.2.0-rc.6" }
+dibs-qgen = { path = "crates/dibs-qgen", version = "0.2.0-rc.6" }
+dibs-query-schema = { path = "crates/dibs-query-schema", version = "0.2.0-rc.6" }
+dibs-db-schema = { path = "crates/dibs-db-schema", version = "0.2.0-rc.6" }
+dibs-jsonb = { path = "crates/dibs-jsonb", version = "0.2.0-rc.6" }
+dibs-runtime = { path = "crates/dibs-runtime", version = "0.2.0-rc.6" }
 dockside = { path = "crates/dockside" }
 
 facet = { version = "0.50.0-rc.7" }
@@ -24,7 +24,7 @@ facet-value = { version = "0.50.0-rc.7" }
 facet-json = { version = "0.50.0-rc.7" }
 facet-reflect = { version = "0.50.0-rc.7" }
 facet-testhelpers = { version = "0.50.0-rc.7" }
-facet-tokio-postgres = { path = "crates/facet-tokio-postgres", version = "0.50.0-rc.5" }
+facet-tokio-postgres = { path = "crates/facet-tokio-postgres", version = "0.50.0-rc.6" }
 figue = { version = "5.0.0-rc.6" }
 strid = { version = "11.0.0-rc.5" }
 

--- a/crates/dibs-cli/Cargo.toml
+++ b/crates/dibs-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-cli"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 authors = ["Amos Wenger <amos@bearcove.eu>"]

--- a/crates/dibs-config/Cargo.toml
+++ b/crates/dibs-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-config"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "Facet types for the dibs configuration schema"

--- a/crates/dibs-db-schema/Cargo.toml
+++ b/crates/dibs-db-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-db-schema"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 authors = ["Amos Wenger <amos@bearcove.eu>"]
@@ -15,8 +15,8 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 chrono.workspace = true
-dibs-jsonb = { version = "0.2.0-rc.5", path = "../dibs-jsonb" }
-dibs-sql = { version = "0.2.0-rc.5", path = "../dibs-sql" }
+dibs-jsonb = { version = "0.2.0-rc.6", path = "../dibs-jsonb" }
+dibs-sql = { version = "0.2.0-rc.6", path = "../dibs-sql" }
 facet = { workspace = true, features = ["uuid", "chrono", "rust_decimal", "jiff02"] }
 indexmap.workspace = true
 inventory.workspace = true

--- a/crates/dibs-jsonb/Cargo.toml
+++ b/crates/dibs-jsonb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-jsonb"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "JSONB column support for dibs (Jsonb<T> wrapper for Facet types)"

--- a/crates/dibs-macros/Cargo.toml
+++ b/crates/dibs-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-macros"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 authors = ["Amos Wenger <amos@bearcove.eu>"]

--- a/crates/dibs-proto/Cargo.toml
+++ b/crates/dibs-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-proto"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 authors = ["Amos Wenger <amos@bearcove.eu>"]

--- a/crates/dibs-qgen/Cargo.toml
+++ b/crates/dibs-qgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-qgen"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "Query DSL code generator for dibs (parses .styx query files into Rust and SQL)"
@@ -12,9 +12,9 @@ license = "MIT OR Apache-2.0"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-dibs-db-schema = { version = "0.2.0-rc.5", path = "../dibs-db-schema" }
+dibs-db-schema = { version = "0.2.0-rc.6", path = "../dibs-db-schema" }
 dibs-query-schema.workspace = true
-dibs-sql = { version = "0.2.0-rc.5", path = "../dibs-sql" }
+dibs-sql = { version = "0.2.0-rc.6", path = "../dibs-sql" }
 facet-styx = { workspace = true, features = ["tracing"] }
 codegen.workspace = true
 ariadne.workspace = true

--- a/crates/dibs-query-schema/Cargo.toml
+++ b/crates/dibs-query-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-query-schema"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "Facet types for the dibs query DSL schema"
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-dibs-sql = { version = "0.2.0-rc.5", path = "../dibs-sql" }
+dibs-sql = { version = "0.2.0-rc.6", path = "../dibs-sql" }
 facet = { workspace = true, features = ["indexmap"] }
 facet-reflect.workspace = true
 facet-styx.workspace = true

--- a/crates/dibs-runtime/Cargo.toml
+++ b/crates/dibs-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-runtime"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "Runtime types for dibs-generated query code"
@@ -16,7 +16,7 @@ tokio-postgres.workspace = true
 facet.workspace = true
 facet-tokio-postgres = { workspace = true, features = ["jiff02", "rust_decimal", "uuid"] }
 facet-value.workspace = true
-dibs-jsonb = { version = "0.2.0-rc.5", path = "../dibs-jsonb" }
+dibs-jsonb = { version = "0.2.0-rc.6", path = "../dibs-jsonb" }
 jiff.workspace = true
 uuid.workspace = true
 rust_decimal.workspace = true

--- a/crates/dibs-sql/Cargo.toml
+++ b/crates/dibs-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs-sql"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 description = "Typed SQL AST and renderer for dibs"

--- a/crates/dibs/Cargo.toml
+++ b/crates/dibs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dibs"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 authors = ["Amos Wenger <amos@bearcove.eu>"]

--- a/crates/facet-tokio-postgres/Cargo.toml
+++ b/crates/facet-tokio-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-tokio-postgres"
-version = "0.50.0-rc.5"
+version = "0.50.0-rc.6"
 edition = "2024"
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,20 @@
 # release-plz configuration
-# https://release-plz.ieni.dev/docs/config
-#
-# Publish policy lives in each crate's Cargo.toml via `publish = false`
-# (examples + internal-only crates like dibs-codegen / dockside / xtask).
-# release-plz inherits that automatically, so there are no per-package
-# entries here. Do not re-add `release = false` entries for crates that
-# already set `publish = false` — release-plz errors on the inconsistency.
+# https://release-plz.dev/docs/config
+
+# `publish = false` in Cargo.toml only disables publishing. These workspace
+# packages must also set `release = false` here so release-plz does not package
+# and compare them while preparing releases for public crates.
+[[package]]
+name = "dibs-codegen"
+release = false
+publish = false
+
+[[package]]
+name = "dockside"
+release = false
+publish = false
+
+[[package]]
+name = "xtask"
+release = false
+publish = false


### PR DESCRIPTION
Bootstrap Dibs onto a reconstructible release baseline after the registry dependency cutover.

- bump all public Dibs crates to 0.2.0-rc.6
- bump facet-tokio-postgres to 0.50.0-rc.6
- keep internal path constraints aligned
- explicitly exclude unpublished dibs-codegen, dockside, and xtask from release-plz processing (`publish = false` alone only disables publication)

Why manual bootstrap: historical published source commits depend on deleted private `phon-next` / `strid-next` revisions, so release-plz cannot package them to infer diffs. Every public crate passes `cargo package --list --allow-dirty`; the full workspace passes cargo check --workspace --all-targets and cargo fmt --check.