### PR TITLE
ci: authenticate crates.io with OIDC

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -21,13 +22,16 @@ jobs:
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Get crates.io token via trusted publishing
+        uses: rust-lang/crates-io-auth-action@v1
+        id: crates-io-auth
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -53,4 +57,3 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Use crates.io trusted publishing in the release-plz release job.

- grant `id-token: write` only to the publishing job
- exchange the GitHub OIDC identity with `rust-lang/crates-io-auth-action`
- pass its short-lived token to release-plz
- remove the empty crates.io secret from the release-PR job

All 12 public crates are configured on crates.io for `bearcove/dibs` and `.github/workflows/release-plz.yml`. `actionlint .github/workflows/release-plz.yml` passes.